### PR TITLE
feat(7): 어드민 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ out/
 .vscode/
 
 src/main/resources/application-prod.yml
+src/main/resources/application-local.yml

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,18 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // Swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
+
+    // Mapper
+    implementation 'org.mapstruct:mapstruct:1.5.5.Final'
+    annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
+
+    // DTO 입력값 검증
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/DBP/ticketing_backend/domain/auth/controller/AdminController.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/auth/controller/AdminController.java
@@ -39,7 +39,7 @@ public class AdminController {
 
     // 모든 호스트 목록 조회
     @Operation(summary = "호스트 조회", description = "호스트 정보들을 조회합니다.")
-    @GetMapping("/hosts")
+    @GetMapping("/host")
     public ResponseEntity<AuthResponseDto<List<HostResponseDto>>> getAllHosts() {
         try {
             List<HostResponseDto> hosts = adminService.getAllHosts();

--- a/src/main/java/com/DBP/ticketing_backend/domain/auth/controller/AdminController.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/auth/controller/AdminController.java
@@ -6,6 +6,7 @@ import com.DBP.ticketing_backend.domain.auth.service.AdminService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/DBP/ticketing_backend/domain/auth/controller/AdminController.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/auth/controller/AdminController.java
@@ -4,6 +4,8 @@ import com.DBP.ticketing_backend.domain.auth.dto.response.AuthResponseDto;
 import com.DBP.ticketing_backend.domain.auth.dto.response.HostResponseDto;
 import com.DBP.ticketing_backend.domain.auth.service.AdminService;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.http.ResponseEntity;
@@ -16,14 +18,16 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 @RestController
-@RequestMapping("/admin/hosts")
+@RequestMapping("/api/admin")
 @RequiredArgsConstructor
+@Tag(name = " 어드민 api", description = "어드민의 관리 API 입니다.")
 public class AdminController {
 
     private final AdminService adminService;
 
     // 대기 중인 호스트 목록 조회
-    @GetMapping("/pending")
+    @Operation(summary = "호스트 요청 조회", description = "호스트로 회원가입을 요청한 정보들을 조회합니다.")
+    @GetMapping("host/pending")
     public ResponseEntity<AuthResponseDto<List<HostResponseDto>>> getPendingHosts() {
         try {
             List<HostResponseDto> hosts = adminService.getPendingHosts();
@@ -34,7 +38,8 @@ public class AdminController {
     }
 
     // 모든 호스트 목록 조회
-    @GetMapping
+    @Operation(summary = "호스트 조회", description = "호스트 정보들을 조회합니다.")
+    @GetMapping("/hosts")
     public ResponseEntity<AuthResponseDto<List<HostResponseDto>>> getAllHosts() {
         try {
             List<HostResponseDto> hosts = adminService.getAllHosts();
@@ -45,6 +50,7 @@ public class AdminController {
     }
 
     // 호스트 승인
+    @Operation(summary = "호스트 승인", description = "호스트 회원가입 요청을 승인합니다.")
     @PostMapping("/{hostId}/approve")
     public ResponseEntity<AuthResponseDto<Void>> approveHost(@PathVariable Long hostId) {
         try {
@@ -56,6 +62,7 @@ public class AdminController {
     }
 
     // 호스트 거부
+    @Operation(summary = "호스트 거절", description = "호스트 회원가입 요청을 거절합니다.")
     @PostMapping("/{hostId}/reject")
     public ResponseEntity<AuthResponseDto<Void>> rejectHost(@PathVariable Long hostId) {
         try {
@@ -67,6 +74,7 @@ public class AdminController {
     }
 
     // 호스트 정지
+    @Operation(summary = "호스트 정지", description = "호스트 회원의 계정을 정지합니다.")
     @PostMapping("/{hostId}/suspend")
     public ResponseEntity<AuthResponseDto<Void>> suspendHost(@PathVariable Long hostId) {
         try {
@@ -78,6 +86,7 @@ public class AdminController {
     }
 
     // 호스트 정지 해제
+    @Operation(summary = "호스트 정지 해제", description = "호스트 회원의 계정을 정지를 해제합니다.")
     @PostMapping("/{hostId}/activate")
     public ResponseEntity<AuthResponseDto<Void>> activateHost(@PathVariable Long hostId) {
         try {

--- a/src/main/java/com/DBP/ticketing_backend/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/auth/controller/AuthController.java
@@ -7,6 +7,9 @@ import com.DBP.ticketing_backend.domain.auth.dto.response.AuthResponseDto;
 import com.DBP.ticketing_backend.domain.auth.dto.response.LoginResponseDto;
 import com.DBP.ticketing_backend.domain.auth.service.AuthService;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.http.ResponseEntity;
@@ -20,16 +23,18 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.Map;
 
 @RestController
-@RequestMapping("auth")
+@RequestMapping("/api/auth")
 @RequiredArgsConstructor
+@Tag(name = " Auth api", description = "인증/인가와 관련된 API 입니다.")
 public class AuthController {
 
     private final AuthService authService;
 
     /** 일반 사용자 회원가입 */
+    @Operation(summary = "유저 회원가입", description = "일반 유저로 회원가입 요청을 합니다.")
     @PostMapping("/signup/user")
     public ResponseEntity<AuthResponseDto<Void>> signUpUser(
-            @RequestBody SignUpUserRequestDto request) {
+        @Valid @RequestBody SignUpUserRequestDto request) {
         try {
             authService.saveUser(request);
             return ResponseEntity.ok(AuthResponseDto.success("회원가입이 완료되었습니다."));
@@ -39,18 +44,20 @@ public class AuthController {
     }
 
     /** 호스트 회원가입 */
+    @Operation(summary = "호스트 회원가입", description = "호스트로 회원가입 요청을 합니다.")
     @PostMapping("/signup/host")
     public ResponseEntity<AuthResponseDto<Void>> signUpHost(
-            @RequestBody SignUpHostRequestDto request) {
+        @Valid @RequestBody SignUpHostRequestDto request) {
         try {
             authService.saveHost(request);
-            return ResponseEntity.ok(AuthResponseDto.success("회원가입이 완료되었습니다."));
+            return ResponseEntity.ok(AuthResponseDto.success("회원가입 요청이 완료되었습니다. 승인을 기다려주세요."));
         } catch (IllegalArgumentException e) {
             return ResponseEntity.badRequest().body(AuthResponseDto.error(e.getMessage()));
         }
     }
 
     /** 로그인 */
+    @Operation(summary = "로그인", description = "로그인을 합니다.")
     @PostMapping("/login")
     public ResponseEntity<AuthResponseDto<LoginResponseDto>> login(
             @RequestBody LoginRequestDto request) {
@@ -86,6 +93,7 @@ public class AuthController {
     }
 
     /** 로그아웃 */
+    @Operation(summary = "로그아웃", description = "로그아웃을 합니다.")
     @PostMapping("/logout")
     public ResponseEntity<AuthResponseDto<Void>> logout(
             @RequestHeader("Authorization") String authorizationHeader) {

--- a/src/main/java/com/DBP/ticketing_backend/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/auth/controller/AuthController.java
@@ -9,7 +9,9 @@ import com.DBP.ticketing_backend.domain.auth.service.AuthService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+
 import jakarta.validation.Valid;
+
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.http.ResponseEntity;
@@ -34,7 +36,7 @@ public class AuthController {
     @Operation(summary = "유저 회원가입", description = "일반 유저로 회원가입 요청을 합니다.")
     @PostMapping("/signup/user")
     public ResponseEntity<AuthResponseDto<Void>> signUpUser(
-        @Valid @RequestBody SignUpUserRequestDto request) {
+            @Valid @RequestBody SignUpUserRequestDto request) {
         try {
             authService.saveUser(request);
             return ResponseEntity.ok(AuthResponseDto.success("회원가입이 완료되었습니다."));
@@ -47,7 +49,7 @@ public class AuthController {
     @Operation(summary = "호스트 회원가입", description = "호스트로 회원가입 요청을 합니다.")
     @PostMapping("/signup/host")
     public ResponseEntity<AuthResponseDto<Void>> signUpHost(
-        @Valid @RequestBody SignUpHostRequestDto request) {
+            @Valid @RequestBody SignUpHostRequestDto request) {
         try {
             authService.saveHost(request);
             return ResponseEntity.ok(AuthResponseDto.success("회원가입 요청이 완료되었습니다. 승인을 기다려주세요."));

--- a/src/main/java/com/DBP/ticketing_backend/domain/auth/dto/request/SignUpHostRequestDto.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/auth/dto/request/SignUpHostRequestDto.java
@@ -1,5 +1,9 @@
 package com.DBP.ticketing_backend.domain.auth.dto.request;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -9,10 +13,27 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class SignUpHostRequestDto {
 
+    @NotBlank(message = "이메일은 필수 입력 값입니다.")
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
     private String email;
+
+    @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
+    @Size(min = 8, max = 20, message = "비밀번호는 8자 이상 20자 이하로 입력해주세요.")
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d@$!%*?&]+$",
+        message = "비밀번호는 영문자, 숫자, 특수문자(@$!%*?&)를 포함해야 합니다.")
     private String password;
+
+    @NotBlank(message = "이름은 필수 입력 값입니다.")
     private String name;
+
+    @NotBlank(message = "전화번호는 필수 입력 값입니다.")
+    @Pattern(regexp = "^010\\d{8}$", message = "전화번호는 010으로 시작하는 11자리 숫자여야 합니다. (하이픈 제외)")
     private String phoneNumber;
+
+    @NotBlank(message = "회사명은 필수 입력 값입니다.")
     private String companyName;
+
+    @NotBlank(message = "사업자 등록번호는 필수 입력 값입니다.")
+    @Pattern(regexp = "^\\d{3}-\\d{2}-\\d{5}$", message = "사업자 등록번호 형식이 올바르지 않습니다. (예: 123-45-67890)")
     private String businessNumber;
 }

--- a/src/main/java/com/DBP/ticketing_backend/domain/auth/dto/request/SignUpHostRequestDto.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/auth/dto/request/SignUpHostRequestDto.java
@@ -4,6 +4,7 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -19,8 +20,9 @@ public class SignUpHostRequestDto {
 
     @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
     @Size(min = 8, max = 20, message = "비밀번호는 8자 이상 20자 이하로 입력해주세요.")
-    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d@$!%*?&]+$",
-        message = "비밀번호는 영문자, 숫자, 특수문자(@$!%*?&)를 포함해야 합니다.")
+    @Pattern(
+            regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d@$!%*?&]+$",
+            message = "비밀번호는 영문자, 숫자, 특수문자(@$!%*?&)를 포함해야 합니다.")
     private String password;
 
     @NotBlank(message = "이름은 필수 입력 값입니다.")
@@ -34,6 +36,8 @@ public class SignUpHostRequestDto {
     private String companyName;
 
     @NotBlank(message = "사업자 등록번호는 필수 입력 값입니다.")
-    @Pattern(regexp = "^\\d{3}-\\d{2}-\\d{5}$", message = "사업자 등록번호 형식이 올바르지 않습니다. (예: 123-45-67890)")
+    @Pattern(
+            regexp = "^\\d{3}-\\d{2}-\\d{5}$",
+            message = "사업자 등록번호 형식이 올바르지 않습니다. (예: 123-45-67890)")
     private String businessNumber;
 }

--- a/src/main/java/com/DBP/ticketing_backend/domain/auth/dto/request/SignUpUserRequestDto.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/auth/dto/request/SignUpUserRequestDto.java
@@ -4,6 +4,7 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -19,8 +20,9 @@ public class SignUpUserRequestDto {
 
     @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
     @Size(min = 8, max = 20, message = "비밀번호는 8자 이상 20자 이하로 입력해주세요.")
-    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d@$!%*?&]+$",
-        message = "비밀번호는 영문자, 숫자, 특수문자(@$!%*?&)를 포함해야 합니다.")
+    @Pattern(
+            regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d@$!%*?&]+$",
+            message = "비밀번호는 영문자, 숫자, 특수문자(@$!%*?&)를 포함해야 합니다.")
     private String password;
 
     @NotBlank(message = "이름은 필수 입력 값입니다.")

--- a/src/main/java/com/DBP/ticketing_backend/domain/auth/dto/request/SignUpUserRequestDto.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/auth/dto/request/SignUpUserRequestDto.java
@@ -1,5 +1,9 @@
 package com.DBP.ticketing_backend.domain.auth.dto.request;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -9,8 +13,20 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class SignUpUserRequestDto {
 
+    @NotBlank(message = "이메일은 필수 입력 값입니다.")
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
     private String email;
+
+    @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
+    @Size(min = 8, max = 20, message = "비밀번호는 8자 이상 20자 이하로 입력해주세요.")
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d@$!%*?&]+$",
+        message = "비밀번호는 영문자, 숫자, 특수문자(@$!%*?&)를 포함해야 합니다.")
     private String password;
+
+    @NotBlank(message = "이름은 필수 입력 값입니다.")
     private String name;
+
+    @NotBlank(message = "전화번호는 필수 입력 값입니다.")
+    @Pattern(regexp = "^010\\d{8}$", message = "전화번호는 010으로 시작하는 11자리 숫자여야 합니다. (하이픈 제외)")
     private String phoneNumber;
 }

--- a/src/main/java/com/DBP/ticketing_backend/domain/auth/service/AdminService.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/auth/service/AdminService.java
@@ -4,9 +4,9 @@ import com.DBP.ticketing_backend.domain.auth.dto.response.HostResponseDto;
 import com.DBP.ticketing_backend.domain.host.entity.Host;
 import com.DBP.ticketing_backend.domain.host.enums.HostStatus;
 import com.DBP.ticketing_backend.domain.host.repository.HostRepository;
-
 import com.DBP.ticketing_backend.global.exception.CustomException;
 import com.DBP.ticketing_backend.global.exception.ErrorCode;
+
 import jakarta.transaction.Transactional;
 
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/DBP/ticketing_backend/domain/auth/service/AdminService.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/auth/service/AdminService.java
@@ -5,6 +5,8 @@ import com.DBP.ticketing_backend.domain.host.entity.Host;
 import com.DBP.ticketing_backend.domain.host.enums.HostStatus;
 import com.DBP.ticketing_backend.domain.host.repository.HostRepository;
 
+import com.DBP.ticketing_backend.global.exception.CustomException;
+import com.DBP.ticketing_backend.global.exception.ErrorCode;
 import jakarta.transaction.Transactional;
 
 import lombok.RequiredArgsConstructor;
@@ -38,10 +40,10 @@ public class AdminService {
         Host host =
                 hostRepository
                         .findById(hostId)
-                        .orElseThrow(() -> new IllegalArgumentException("호스트를 찾을 수 없습니다."));
+                        .orElseThrow(() -> new CustomException(ErrorCode.HOST_NOT_FOUND));
 
         if (host.getStatus() != HostStatus.PENDING) {
-            throw new IllegalStateException("대기 중인 호스트만 승인할 수 있습니다.");
+            throw new CustomException(ErrorCode.NOT_A_PENDING_HOST);
         }
 
         host.approve();
@@ -52,10 +54,10 @@ public class AdminService {
         Host host =
                 hostRepository
                         .findById(hostId)
-                        .orElseThrow(() -> new IllegalArgumentException("호스트를 찾을 수 없습니다."));
+                        .orElseThrow(() -> new CustomException(ErrorCode.HOST_NOT_FOUND));
 
         if (host.getStatus() != HostStatus.PENDING) {
-            throw new IllegalStateException("대기 중인 호스트만 거부할 수 있습니다.");
+            throw new CustomException(ErrorCode.NOT_A_PENDING_HOST);
         }
 
         // 호스트 거부
@@ -67,10 +69,10 @@ public class AdminService {
         Host host =
                 hostRepository
                         .findById(hostId)
-                        .orElseThrow(() -> new IllegalArgumentException("호스트를 찾을 수 없습니다."));
+                        .orElseThrow(() -> new CustomException(ErrorCode.HOST_NOT_FOUND));
 
         if (host.getStatus() != HostStatus.ACTIVE) {
-            throw new IllegalStateException("활성화된 호스트만 정지할 수 있습니다.");
+            throw new CustomException(ErrorCode.NOT_AN_ACTIVATED_HOST);
         }
 
         host.suspend();
@@ -84,7 +86,7 @@ public class AdminService {
                         .orElseThrow(() -> new IllegalArgumentException("호스트를 찾을 수 없습니다."));
 
         if (host.getStatus() != HostStatus.SUSPENDED) {
-            throw new IllegalStateException("정지된 호스트만 활성화할 수 있습니다.");
+            throw new CustomException(ErrorCode.NOT_AN_ACTIVATED_HOST);
         }
 
         host.approve();

--- a/src/main/java/com/DBP/ticketing_backend/domain/auth/service/AuthService.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/auth/service/AuthService.java
@@ -14,9 +14,9 @@ import com.DBP.ticketing_backend.domain.host.repository.HostRepository;
 import com.DBP.ticketing_backend.domain.users.entity.Users;
 import com.DBP.ticketing_backend.domain.users.enums.UsersRole;
 import com.DBP.ticketing_backend.domain.users.repository.UsersRepository;
-
 import com.DBP.ticketing_backend.global.exception.CustomException;
 import com.DBP.ticketing_backend.global.exception.ErrorCode;
+
 import jakarta.transaction.Transactional;
 
 import lombok.RequiredArgsConstructor;
@@ -99,7 +99,8 @@ public class AuthService implements UserDetailsService {
         Users user =
                 usersRepository
                         .findByEmail(email)
-                        .orElseThrow(() -> new CustomException(ErrorCode.INVALID_EMAIL_OR_PASSWORD));
+                        .orElseThrow(
+                                () -> new CustomException(ErrorCode.INVALID_EMAIL_OR_PASSWORD));
 
         if (!passwordEncoder.matches(password, user.getPassword())) {
             throw new CustomException(ErrorCode.INVALID_EMAIL_OR_PASSWORD);
@@ -161,8 +162,7 @@ public class AuthService implements UserDetailsService {
         RefreshToken storedToken =
                 refreshTokenRepository
                         .findByToken(refreshToken)
-                        .orElseThrow(
-                                () -> new CustomException(ErrorCode.TOKEN_NOT_FOUND));
+                        .orElseThrow(() -> new CustomException(ErrorCode.TOKEN_NOT_FOUND));
 
         // 만료 확인
         if (storedToken.isExpired()) {

--- a/src/main/java/com/DBP/ticketing_backend/domain/users/enums/UsersRole.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/users/enums/UsersRole.java
@@ -6,9 +6,9 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum UsersRole {
-    USER("USER", "일반 사용자"),
-    ADMIN("ADMIN", "관리자"),
-    HOST("HOST", "호스트");
+    ROLE_USER("ROLE_USER", "일반 사용자"),
+    ROLE_ADMIN("ROLE_ADMIN", "관리자"),
+    ROLE_HOST("ROLE_HOST", "호스트");
 
     private final String key;
     private final String description;

--- a/src/main/java/com/DBP/ticketing_backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/DBP/ticketing_backend/global/config/SecurityConfig.java
@@ -39,14 +39,14 @@ public class SecurityConfig {
                         auth -> {
                             // 인증 없이 접근 가능한 경로
                             auth.requestMatchers(
-                                            "/auth/signup/**", // 회원가입
-                                            "/auth/login", // 로그인
-                                            "/auth/refresh" // 토큰 재발급
+                                            "/api/auth/signup/**", // 회원가입
+                                            "/api/auth/login", // 로그인
+                                            "/api/auth/refresh" // 토큰 재발급
                                             )
                                     .permitAll();
 
                             // 로그아웃은 인증 필요
-                            auth.requestMatchers("/auth/logout").authenticated();
+                            auth.requestMatchers("/api/auth/logout").authenticated();
 
                             // ADMIN만 접근 가능
                             auth.requestMatchers("/admin/**").hasRole("ADMIN");

--- a/src/main/java/com/DBP/ticketing_backend/global/config/SwaggerConfig.java
+++ b/src/main/java/com/DBP/ticketing_backend/global/config/SwaggerConfig.java
@@ -1,0 +1,16 @@
+package com.DBP.ticketing_backend.global.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI().info(new Info().title("Ticketing API").version("1.0"));
+    }
+}

--- a/src/main/java/com/DBP/ticketing_backend/global/exception/CustomException.java
+++ b/src/main/java/com/DBP/ticketing_backend/global/exception/CustomException.java
@@ -1,0 +1,11 @@
+package com.DBP.ticketing_backend.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+    int errorCode;
+
+    public CustomException(ErrorCode errorCode) {}
+}

--- a/src/main/java/com/DBP/ticketing_backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/DBP/ticketing_backend/global/exception/ErrorCode.java
@@ -1,6 +1,7 @@
 package com.DBP.ticketing_backend.global.exception;
 
 import lombok.Getter;
+
 import org.springframework.http.HttpStatus;
 
 @Getter

--- a/src/main/java/com/DBP/ticketing_backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/DBP/ticketing_backend/global/exception/ErrorCode.java
@@ -1,0 +1,39 @@
+package com.DBP.ticketing_backend.global.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode {
+
+    // 400 Bad Request: 잘못된 요청
+    NOT_A_PENDING_HOST(HttpStatus.BAD_REQUEST, "대기중인 호스트가 아닙니다."),
+    NOT_AN_ACTIVATED_HOST(HttpStatus.BAD_REQUEST, "활성화된 호스트가 아닙니다."),
+    INVALID_EMAIL_OR_PASSWORD(HttpStatus.BAD_REQUEST, "이메일 또는 비밀번호가 올바르지 않습니다."),
+
+    // 401 Unauthorized: 인증되지 않은 사용자
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요한 요청입니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
+    UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "권한이 없는 접근입니다."),
+
+    // 404 Not Found: 리소스를 찾을 수 없음
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자를 찾을 수 없습니다."),
+    HOST_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 호스트를 찾을 수 없습니다."),
+    TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 토큰을 찾을 수 없습니다."),
+
+    // 409 Conflict: 충돌
+    DUPLICATE_MEMBER_EMAIL(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),
+    DUPLICATE_BUSINESS_NUMBER(HttpStatus.CONFLICT, "이미 등록된 사업자번호입니다."),
+
+    // 500 Internal Server Error: 서버 내부 오류
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부에 알 수 없는 오류가 발생했습니다.");
+
+    private final HttpStatus status; // HTTP 상태 코드
+    private final String message; // 에러 메시지
+
+    ErrorCode(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/DBP/ticketing_backend/global/exception/ErrorResponse.java
+++ b/src/main/java/com/DBP/ticketing_backend/global/exception/ErrorResponse.java
@@ -1,0 +1,12 @@
+package com.DBP.ticketing_backend.global.exception;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ErrorResponse {
+
+    private final int status;
+    private final String message;
+}

--- a/src/main/java/com/DBP/ticketing_backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/DBP/ticketing_backend/global/exception/GlobalExceptionHandler.java
@@ -1,7 +1,5 @@
 package com.DBP.ticketing_backend.global.exception;
 
-import java.util.HashMap;
-import java.util.Map;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
@@ -10,13 +8,16 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.util.HashMap;
+import java.util.Map;
+
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
     // MethodArgumentNotValidException 예외를 특별히 처리하는 메서드
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<Map<String, String>> handleValidationExceptions(
-        MethodArgumentNotValidException ex) {
+            MethodArgumentNotValidException ex) {
 
         // 에러 메시지를 담을 Map 생성
         Map<String, String> errors = new HashMap<>();

--- a/src/main/java/com/DBP/ticketing_backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/DBP/ticketing_backend/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,34 @@
+package com.DBP.ticketing_backend.global.exception;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // MethodArgumentNotValidException 예외를 특별히 처리하는 메서드
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, String>> handleValidationExceptions(
+        MethodArgumentNotValidException ex) {
+
+        // 에러 메시지를 담을 Map 생성
+        Map<String, String> errors = new HashMap<>();
+
+        // 예외 결과(BindingResult)에서 모든 필드 에러(FieldError)를 가져옴
+        BindingResult bindingResult = ex.getBindingResult();
+        for (FieldError fieldError : bindingResult.getFieldErrors()) {
+            // 어떤 필드에서 에러가 났는지(field)와 DTO에 설정한 메시지(message)를 Map에 담음
+            errors.put(fieldError.getField(), fieldError.getDefaultMessage());
+        }
+
+        // 400 Bad Request 상태 코드와 함께 에러 메시지를 담은 Map을 응답으로 보냄
+        return new ResponseEntity<>(errors, HttpStatus.BAD_REQUEST);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #7 

## 📝작업 내용
- Auth, Admin에 Swagger 설정
- CustomException 및 ErrorCode 설정
- 유저 역할에 "Role_" 을 붙여서 hasRole()로 역할 확인이 가능하도록 변경
- User 계정을 두 개 생각하여 쿼리와 API를 통해 Admin과 Host 생성 

## 📸 스크린샷 (선택)
<img width="2016" height="986" alt="image" src="https://github.com/user-attachments/assets/21a337f5-7633-45fc-9929-e4bcac06d1d7" />


## 🧪 테스트 여부
- [ ] 테스트 코드를 작성함
- [ ] 테스트를 수행함

## 💬리뷰 요구사항(선택)
- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?