### PR TITLE
feat(9): 장소 설정

### DIFF
--- a/src/main/java/com/DBP/ticketing_backend/domain/place/controller/PlaceController.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/place/controller/PlaceController.java
@@ -4,7 +4,9 @@ import com.DBP.ticketing_backend.domain.auth.dto.UsersDetails;
 import com.DBP.ticketing_backend.domain.place.dto.CreatePlaceRequestDto;
 import com.DBP.ticketing_backend.domain.place.dto.PlaceResponseDto;
 import com.DBP.ticketing_backend.domain.place.service.PlaceService;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -24,22 +26,22 @@ public class PlaceController {
 
     @PostMapping("/create")
     public ResponseEntity<Long> createPlace(
-        @RequestBody CreatePlaceRequestDto createPlaceRequestDto,
-        @AuthenticationPrincipal UsersDetails usersDetails) {
+            @RequestBody CreatePlaceRequestDto createPlaceRequestDto,
+            @AuthenticationPrincipal UsersDetails usersDetails) {
         return ResponseEntity.ok(placeService.createPlace(createPlaceRequestDto, usersDetails));
     }
 
     @GetMapping("/{placeId}")
     public ResponseEntity<PlaceResponseDto> getPlace(
-        @PathVariable("placeId") Long placeId,
-        @AuthenticationPrincipal UsersDetails usersDetails) {
+            @PathVariable("placeId") Long placeId,
+            @AuthenticationPrincipal UsersDetails usersDetails) {
         return ResponseEntity.ok(placeService.getPlace(placeId, usersDetails));
     }
 
     @DeleteMapping("/{placeId}")
     public ResponseEntity<Void> deletePlace(
-        @PathVariable("placeId") Long placeId,
-        @AuthenticationPrincipal UsersDetails usersDetails) {
+            @PathVariable("placeId") Long placeId,
+            @AuthenticationPrincipal UsersDetails usersDetails) {
         placeService.deletePlace(placeId, usersDetails);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/DBP/ticketing_backend/domain/place/controller/PlaceController.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/place/controller/PlaceController.java
@@ -1,0 +1,46 @@
+package com.DBP.ticketing_backend.domain.place.controller;
+
+import com.DBP.ticketing_backend.domain.auth.dto.UsersDetails;
+import com.DBP.ticketing_backend.domain.place.dto.CreatePlaceRequestDto;
+import com.DBP.ticketing_backend.domain.place.dto.PlaceResponseDto;
+import com.DBP.ticketing_backend.domain.place.service.PlaceService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/place")
+@RequiredArgsConstructor
+public class PlaceController {
+
+    private final PlaceService placeService;
+
+    @PostMapping("/create")
+    public ResponseEntity<Long> createPlace(
+        @RequestBody CreatePlaceRequestDto createPlaceRequestDto,
+        @AuthenticationPrincipal UsersDetails usersDetails) {
+        return ResponseEntity.ok(placeService.createPlace(createPlaceRequestDto, usersDetails));
+    }
+
+    @GetMapping("/{placeId}")
+    public ResponseEntity<PlaceResponseDto> getPlace(
+        @PathVariable("placeId") Long placeId,
+        @AuthenticationPrincipal UsersDetails usersDetails) {
+        return ResponseEntity.ok(placeService.getPlace(placeId, usersDetails));
+    }
+
+    @DeleteMapping("/{placeId}")
+    public ResponseEntity<Void> deletePlace(
+        @PathVariable("placeId") Long placeId,
+        @AuthenticationPrincipal UsersDetails usersDetails) {
+        placeService.deletePlace(placeId, usersDetails);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/DBP/ticketing_backend/domain/place/dto/CreatePlaceRequestDto.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/place/dto/CreatePlaceRequestDto.java
@@ -1,0 +1,36 @@
+package com.DBP.ticketing_backend.domain.place.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import lombok.Data;
+
+@Data
+public class CreatePlaceRequestDto {
+
+    @NotBlank(message = "장소명은 필수입니다.")
+    private String placeName;
+
+    @NotBlank(message = "주소는 필수입니다.")
+    private String address;
+
+    @NotEmpty(message = "최소 하나 이상의 구역이 필요합니다.")
+    private List<CreateSectionDto> sections;
+
+    @Data
+    public static class CreateSectionDto {
+        @NotBlank(message = "구역명은 필수입니다.")
+        private String sectionName; // 예: "A"
+
+        @NotNull
+        @Min(value = 1, message = "행은 1 이상이어야 합니다.")
+        private Integer rows; // n
+
+        @NotNull
+        @Min(value = 1, message = "열은 1 이상이어야 합니다.")
+        private Integer columns; // m
+    }
+
+}

--- a/src/main/java/com/DBP/ticketing_backend/domain/place/dto/CreatePlaceRequestDto.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/place/dto/CreatePlaceRequestDto.java
@@ -4,8 +4,10 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
-import java.util.List;
+
 import lombok.Data;
+
+import java.util.List;
 
 @Data
 public class CreatePlaceRequestDto {
@@ -32,5 +34,4 @@ public class CreatePlaceRequestDto {
         @Min(value = 1, message = "열은 1 이상이어야 합니다.")
         private Integer columns; // m
     }
-
 }

--- a/src/main/java/com/DBP/ticketing_backend/domain/place/dto/PlaceResponseDto.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/place/dto/PlaceResponseDto.java
@@ -2,14 +2,16 @@ package com.DBP.ticketing_backend.domain.place.dto;
 
 import com.DBP.ticketing_backend.domain.place.entity.Place;
 import com.DBP.ticketing_backend.domain.seattemplate.entity.SeatTemplate;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Data
 @Builder
@@ -26,45 +28,48 @@ public class PlaceResponseDto {
     @NoArgsConstructor
     public static class SectionInfo {
         private String sectionName; // 구역명 (예: "A")
-        private Integer rowCount;   // 행 개수 (n)
-        private Integer colCount;   // 열 개수 (m)
+        private Integer rowCount; // 행 개수 (n)
+        private Integer colCount; // 열 개수 (m)
     }
 
     public static PlaceResponseDto from(Place place, List<SeatTemplate> templates) {
 
-        Map<String, List<SeatTemplate>> groupedBySection = templates.stream()
-            .collect(Collectors.groupingBy(SeatTemplate::getSection));
+        Map<String, List<SeatTemplate>> groupedBySection =
+                templates.stream().collect(Collectors.groupingBy(SeatTemplate::getSection));
 
-        List<SectionInfo> sectionInfos = groupedBySection.entrySet().stream()
-            .map(entry -> {
-                String sectionName = entry.getKey();
-                List<SeatTemplate> seats = entry.getValue();
+        List<SectionInfo> sectionInfos =
+                groupedBySection.entrySet().stream()
+                        .map(
+                                entry -> {
+                                    String sectionName = entry.getKey();
+                                    List<SeatTemplate> seats = entry.getValue();
 
-                int maxRow = seats.stream()
-                    .mapToInt(SeatTemplate::getRow)
-                    .max()
-                    .orElse(0);
+                                    int maxRow =
+                                            seats.stream()
+                                                    .mapToInt(SeatTemplate::getRow)
+                                                    .max()
+                                                    .orElse(0);
 
-                int maxCol = seats.stream()
-                    .mapToInt(SeatTemplate::getColumn)
-                    .max()
-                    .orElse(0);
+                                    int maxCol =
+                                            seats.stream()
+                                                    .mapToInt(SeatTemplate::getColumn)
+                                                    .max()
+                                                    .orElse(0);
 
-                return SectionInfo.builder()
-                    .sectionName(sectionName)
-                    .rowCount(maxRow)
-                    .colCount(maxCol)
-                    .build();
-            })
-            .sorted(Comparator.comparing(SectionInfo::getSectionName))
-            .collect(Collectors.toList());
+                                    return SectionInfo.builder()
+                                            .sectionName(sectionName)
+                                            .rowCount(maxRow)
+                                            .colCount(maxCol)
+                                            .build();
+                                })
+                        .sorted(Comparator.comparing(SectionInfo::getSectionName))
+                        .collect(Collectors.toList());
 
         return PlaceResponseDto.builder()
-            .placeId(place.getPlaceId())
-            .placeName(place.getPlaceName())
-            .address(place.getAddress())
-            .sections(sectionInfos)
-            .build();
+                .placeId(place.getPlaceId())
+                .placeName(place.getPlaceName())
+                .address(place.getAddress())
+                .sections(sectionInfos)
+                .build();
     }
-
 }

--- a/src/main/java/com/DBP/ticketing_backend/domain/place/dto/PlaceResponseDto.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/place/dto/PlaceResponseDto.java
@@ -1,0 +1,70 @@
+package com.DBP.ticketing_backend.domain.place.dto;
+
+import com.DBP.ticketing_backend.domain.place.entity.Place;
+import com.DBP.ticketing_backend.domain.seattemplate.entity.SeatTemplate;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+public class PlaceResponseDto {
+
+    private Long placeId;
+    private String placeName;
+    private String address;
+    private List<SectionInfo> sections;
+
+    @Data
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class SectionInfo {
+        private String sectionName; // 구역명 (예: "A")
+        private Integer rowCount;   // 행 개수 (n)
+        private Integer colCount;   // 열 개수 (m)
+    }
+
+    public static PlaceResponseDto from(Place place, List<SeatTemplate> templates) {
+
+        Map<String, List<SeatTemplate>> groupedBySection = templates.stream()
+            .collect(Collectors.groupingBy(SeatTemplate::getSection));
+
+        List<SectionInfo> sectionInfos = groupedBySection.entrySet().stream()
+            .map(entry -> {
+                String sectionName = entry.getKey();
+                List<SeatTemplate> seats = entry.getValue();
+
+                int maxRow = seats.stream()
+                    .mapToInt(SeatTemplate::getRow)
+                    .max()
+                    .orElse(0);
+
+                int maxCol = seats.stream()
+                    .mapToInt(SeatTemplate::getColumn)
+                    .max()
+                    .orElse(0);
+
+                return SectionInfo.builder()
+                    .sectionName(sectionName)
+                    .rowCount(maxRow)
+                    .colCount(maxCol)
+                    .build();
+            })
+            .sorted(Comparator.comparing(SectionInfo::getSectionName))
+            .collect(Collectors.toList());
+
+        return PlaceResponseDto.builder()
+            .placeId(place.getPlaceId())
+            .placeName(place.getPlaceName())
+            .address(place.getAddress())
+            .sections(sectionInfos)
+            .build();
+    }
+
+}

--- a/src/main/java/com/DBP/ticketing_backend/domain/place/repository/PlaceRepository.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/place/repository/PlaceRepository.java
@@ -1,0 +1,8 @@
+package com.DBP.ticketing_backend.domain.place.repository;
+
+import com.DBP.ticketing_backend.domain.place.entity.Place;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PlaceRepository extends JpaRepository<Place, Long> {
+
+}

--- a/src/main/java/com/DBP/ticketing_backend/domain/place/repository/PlaceRepository.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/place/repository/PlaceRepository.java
@@ -1,8 +1,7 @@
 package com.DBP.ticketing_backend.domain.place.repository;
 
 import com.DBP.ticketing_backend.domain.place.entity.Place;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface PlaceRepository extends JpaRepository<Place, Long> {
-
-}
+public interface PlaceRepository extends JpaRepository<Place, Long> {}

--- a/src/main/java/com/DBP/ticketing_backend/domain/place/service/PlaceService.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/place/service/PlaceService.java
@@ -12,11 +12,14 @@ import com.DBP.ticketing_backend.domain.users.enums.UsersRole;
 import com.DBP.ticketing_backend.domain.users.repository.UsersRepository;
 import com.DBP.ticketing_backend.global.exception.CustomException;
 import com.DBP.ticketing_backend.global.exception.ErrorCode;
-import java.util.ArrayList;
-import java.util.List;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -31,10 +34,11 @@ public class PlaceService {
 
         validateAdmin(usersDetails);
 
-        Place place = Place.builder()
-            .placeName(requestDto.getPlaceName())
-            .address(requestDto.getAddress())
-            .build();
+        Place place =
+                Place.builder()
+                        .placeName(requestDto.getPlaceName())
+                        .address(requestDto.getAddress())
+                        .build();
 
         Place savedPlace = placeRepository.save(place);
 
@@ -48,12 +52,13 @@ public class PlaceService {
 
             for (int r = 1; r <= rows; r++) {
                 for (int c = 1; c <= cols; c++) {
-                    SeatTemplate seatTemplate = SeatTemplate.builder()
-                        .place(savedPlace)
-                        .section(sectionName)
-                        .row(r)
-                        .column(c)
-                        .build();
+                    SeatTemplate seatTemplate =
+                            SeatTemplate.builder()
+                                    .place(savedPlace)
+                                    .section(sectionName)
+                                    .row(r)
+                                    .column(c)
+                                    .build();
 
                     seatTemplates.add(seatTemplate);
                 }
@@ -87,8 +92,10 @@ public class PlaceService {
     }
 
     private void validateAdmin(UsersDetails usersDetails) {
-        Users user = usersRepository.findById(usersDetails.getUserId())
-            .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+        Users user =
+                usersRepository
+                        .findById(usersDetails.getUserId())
+                        .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
         if (user.getRole() != UsersRole.ROLE_ADMIN) {
             throw new CustomException(ErrorCode.UNAUTHORIZED_ACCESS);
@@ -96,7 +103,8 @@ public class PlaceService {
     }
 
     private Place findPlaceById(Long placeId) {
-        return placeRepository.findById(placeId)
-            .orElseThrow(() -> new CustomException(ErrorCode.PLACE_NOT_FOUND));
+        return placeRepository
+                .findById(placeId)
+                .orElseThrow(() -> new CustomException(ErrorCode.PLACE_NOT_FOUND));
     }
 }

--- a/src/main/java/com/DBP/ticketing_backend/domain/place/service/PlaceService.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/place/service/PlaceService.java
@@ -1,0 +1,102 @@
+package com.DBP.ticketing_backend.domain.place.service;
+
+import com.DBP.ticketing_backend.domain.auth.dto.UsersDetails;
+import com.DBP.ticketing_backend.domain.place.dto.CreatePlaceRequestDto;
+import com.DBP.ticketing_backend.domain.place.dto.PlaceResponseDto;
+import com.DBP.ticketing_backend.domain.place.entity.Place;
+import com.DBP.ticketing_backend.domain.place.repository.PlaceRepository;
+import com.DBP.ticketing_backend.domain.seattemplate.entity.SeatTemplate;
+import com.DBP.ticketing_backend.domain.seattemplate.repository.SeatTemplateRepository;
+import com.DBP.ticketing_backend.domain.users.entity.Users;
+import com.DBP.ticketing_backend.domain.users.enums.UsersRole;
+import com.DBP.ticketing_backend.domain.users.repository.UsersRepository;
+import com.DBP.ticketing_backend.global.exception.CustomException;
+import com.DBP.ticketing_backend.global.exception.ErrorCode;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PlaceService {
+
+    private final PlaceRepository placeRepository;
+    private final SeatTemplateRepository seatTemplateRepository;
+    private final UsersRepository usersRepository;
+
+    @Transactional
+    public Long createPlace(CreatePlaceRequestDto requestDto, UsersDetails usersDetails) {
+
+        validateAdmin(usersDetails);
+
+        Place place = Place.builder()
+            .placeName(requestDto.getPlaceName())
+            .address(requestDto.getAddress())
+            .build();
+
+        Place savedPlace = placeRepository.save(place);
+
+        List<SeatTemplate> seatTemplates = new ArrayList<>();
+
+        for (CreatePlaceRequestDto.CreateSectionDto sectionDto : requestDto.getSections()) {
+
+            String sectionName = sectionDto.getSectionName();
+            int rows = sectionDto.getRows();
+            int cols = sectionDto.getColumns();
+
+            for (int r = 1; r <= rows; r++) {
+                for (int c = 1; c <= cols; c++) {
+                    SeatTemplate seatTemplate = SeatTemplate.builder()
+                        .place(savedPlace)
+                        .section(sectionName)
+                        .row(r)
+                        .column(c)
+                        .build();
+
+                    seatTemplates.add(seatTemplate);
+                }
+            }
+        }
+        seatTemplateRepository.saveAll(seatTemplates);
+
+        return savedPlace.getPlaceId();
+    }
+
+    @Transactional(readOnly = true)
+    public PlaceResponseDto getPlace(Long placeId, UsersDetails usersDetails) {
+
+        validateAdmin(usersDetails);
+
+        Place place = findPlaceById(placeId);
+
+        List<SeatTemplate> templates = seatTemplateRepository.findAllByPlace(place);
+
+        return PlaceResponseDto.from(place, templates);
+    }
+
+    public void deletePlace(Long placeId, UsersDetails usersDetails) {
+
+        validateAdmin(usersDetails);
+
+        Place place = findPlaceById(placeId);
+
+        seatTemplateRepository.deleteByPlace(place);
+        placeRepository.delete(place);
+    }
+
+    private void validateAdmin(UsersDetails usersDetails) {
+        Users user = usersRepository.findById(usersDetails.getUserId())
+            .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        if (user.getRole() != UsersRole.ROLE_ADMIN) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED_ACCESS);
+        }
+    }
+
+    private Place findPlaceById(Long placeId) {
+        return placeRepository.findById(placeId)
+            .orElseThrow(() -> new CustomException(ErrorCode.PLACE_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/DBP/ticketing_backend/domain/seattemplate/repository/SeatTemplateRepository.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/seattemplate/repository/SeatTemplateRepository.java
@@ -1,0 +1,13 @@
+package com.DBP.ticketing_backend.domain.seattemplate.repository;
+
+import com.DBP.ticketing_backend.domain.place.entity.Place;
+import com.DBP.ticketing_backend.domain.seattemplate.entity.SeatTemplate;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SeatTemplateRepository extends JpaRepository<SeatTemplate, Long> {
+
+    List<SeatTemplate> findAllByPlace(Place place);
+
+    void deleteByPlace(Place place);
+}

--- a/src/main/java/com/DBP/ticketing_backend/domain/seattemplate/repository/SeatTemplateRepository.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/seattemplate/repository/SeatTemplateRepository.java
@@ -2,8 +2,10 @@ package com.DBP.ticketing_backend.domain.seattemplate.repository;
 
 import com.DBP.ticketing_backend.domain.place.entity.Place;
 import com.DBP.ticketing_backend.domain.seattemplate.entity.SeatTemplate;
-import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
 
 public interface SeatTemplateRepository extends JpaRepository<SeatTemplate, Long> {
 

--- a/src/main/java/com/DBP/ticketing_backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/DBP/ticketing_backend/global/config/SecurityConfig.java
@@ -49,10 +49,11 @@ public class SecurityConfig {
                             auth.requestMatchers("/api/auth/logout").authenticated();
 
                             // ADMIN만 접근 가능
-                            auth.requestMatchers("/admin/**").hasRole("ADMIN");
+                            auth.requestMatchers("/api/admin/**").hasRole("ADMIN");
+                            auth.requestMatchers("/api/place/**").hasRole("ADMIN");
 
                             // HOST만 접근 가능
-                            auth.requestMatchers("/host/**").hasRole("HOST");
+                            auth.requestMatchers("/api/host/**").hasRole("HOST");
 
                             // USER, HOST 모두 접근 가능
                             auth.requestMatchers("/api/**").authenticated();

--- a/src/main/java/com/DBP/ticketing_backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/DBP/ticketing_backend/global/exception/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자를 찾을 수 없습니다."),
     HOST_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 호스트를 찾을 수 없습니다."),
     TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 토큰을 찾을 수 없습니다."),
+    PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 장소를 찾을 수 없습니다."),
 
     // 409 Conflict: 충돌
     DUPLICATE_MEMBER_EMAIL(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #9 

## 📝작업 내용
- 장소 생성, 조회, 삭제 관련하여 관리자의 권한으로 수행 가능하게 구현
- 장소명, 주소, 각 섹터 이름과 행렬정보를 통해 Place와 SeatTemplate 동시에 생성

## 📸 스크린샷 (선택)
<img width="2020" height="1416" alt="image" src="https://github.com/user-attachments/assets/b3aba188-6f2e-46b2-81a9-bab4bb06720b" />

## 🧪 테스트 여부
- [ ] 테스트 코드를 작성함
- [ ] 테스트를 수행함

## 💬리뷰 요구사항(선택)
- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?