### PR TITLE
feat(13): 예매기능 구현

### DIFF
--- a/src/main/java/com/DBP/ticketing_backend/domain/auth/service/JwtAuthenticationFilter.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/auth/service/JwtAuthenticationFilter.java
@@ -49,13 +49,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
                     // 5. 이메일로 사용자 정보 조회
                     UserDetails userDetails = authService.loadUserByUsername(email);
-                    log.info("=================================================");
-                    log.info("🚦 Security Filter Check");
-                    log.info("1. Request URI      : {}", requestURI);
-                    log.info("2. Authenticated User : {}", email);
-                    // 이 부분이 [ROLE_ADMIN] 인지 [ADMIN] 인지 확인해야 합니다.
-                    log.info("3. Loaded Authorities : {}", userDetails.getAuthorities());
-                    log.info("=================================================");
 
                     // 6. Authentication 객체 생성
                     UsernamePasswordAuthenticationToken authentication =

--- a/src/main/java/com/DBP/ticketing_backend/domain/bookedseat/entity/BookedSeat.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/bookedseat/entity/BookedSeat.java
@@ -15,9 +15,11 @@ import jakarta.persistence.ManyToOne;
 
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class BookedSeat extends BaseEntity {
 

--- a/src/main/java/com/DBP/ticketing_backend/domain/bookedseat/repository/BookedSeatRepository.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/bookedseat/repository/BookedSeatRepository.java
@@ -2,8 +2,10 @@ package com.DBP.ticketing_backend.domain.bookedseat.repository;
 
 import com.DBP.ticketing_backend.domain.bookedseat.entity.BookedSeat;
 import com.DBP.ticketing_backend.domain.booking.entity.Booking;
-import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
 
 public interface BookedSeatRepository extends JpaRepository<BookedSeat, Long> {
 

--- a/src/main/java/com/DBP/ticketing_backend/domain/bookedseat/repository/BookedSeatRepository.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/bookedseat/repository/BookedSeatRepository.java
@@ -1,0 +1,11 @@
+package com.DBP.ticketing_backend.domain.bookedseat.repository;
+
+import com.DBP.ticketing_backend.domain.bookedseat.entity.BookedSeat;
+import com.DBP.ticketing_backend.domain.booking.entity.Booking;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BookedSeatRepository extends JpaRepository<BookedSeat, Long> {
+
+    Optional<BookedSeat> findByBooking(Booking booking);
+}

--- a/src/main/java/com/DBP/ticketing_backend/domain/bookedseathistory/repository/BookedSeatHistoryRepository.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/bookedseathistory/repository/BookedSeatHistoryRepository.java
@@ -1,0 +1,8 @@
+package com.DBP.ticketing_backend.domain.bookedseathistory.repository;
+
+import com.DBP.ticketing_backend.domain.bookedseathistory.entity.BookedSeatHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BookedSeatHistoryRepository extends JpaRepository<BookedSeatHistory, Long> {
+
+}

--- a/src/main/java/com/DBP/ticketing_backend/domain/bookedseathistory/repository/BookedSeatHistoryRepository.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/bookedseathistory/repository/BookedSeatHistoryRepository.java
@@ -1,8 +1,7 @@
 package com.DBP.ticketing_backend.domain.bookedseathistory.repository;
 
 import com.DBP.ticketing_backend.domain.bookedseathistory.entity.BookedSeatHistory;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface BookedSeatHistoryRepository extends JpaRepository<BookedSeatHistory, Long> {
-
-}
+public interface BookedSeatHistoryRepository extends JpaRepository<BookedSeatHistory, Long> {}

--- a/src/main/java/com/DBP/ticketing_backend/domain/booking/controller/BookingController.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/booking/controller/BookingController.java
@@ -5,10 +5,12 @@ import com.DBP.ticketing_backend.domain.booking.dto.BookingRequestDto;
 import com.DBP.ticketing_backend.domain.booking.dto.BookingResponseDto;
 import com.DBP.ticketing_backend.domain.booking.enums.BookingStatus;
 import com.DBP.ticketing_backend.domain.booking.service.BookingService;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.List;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -19,6 +21,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/booking")
@@ -31,33 +35,35 @@ public class BookingController {
     @Operation(summary = "예매 생성", description = "이벤트 혹은 좌석 정보로 이벤트를 예매합니다.")
     @PostMapping
     public ResponseEntity<BookingResponseDto> createBooking(
-        @AuthenticationPrincipal UsersDetails usersDetails,
-        @RequestBody BookingRequestDto bookingRequestDto) {
+            @AuthenticationPrincipal UsersDetails usersDetails,
+            @RequestBody BookingRequestDto bookingRequestDto) {
         return ResponseEntity.ok(bookingService.createBooking(usersDetails, bookingRequestDto));
     }
 
     @Operation(summary = "예매 취소", description = "결제 대기 혹은 예매 완료된 예매를 취소합니다.")
     @DeleteMapping("/{bookingId}")
     public ResponseEntity<BookingResponseDto> cancelBooking(
-        @AuthenticationPrincipal UsersDetails usersDetails,
-        @PathVariable("bookingId") Long bookingId) {
+            @AuthenticationPrincipal UsersDetails usersDetails,
+            @PathVariable("bookingId") Long bookingId) {
         return ResponseEntity.ok(bookingService.cancelBooking(usersDetails, bookingId));
     }
 
     @Operation(summary = "결제", description = "결제를 통해 예매를 확정합니다.")
     @PostMapping("/{bookingId}")
     public ResponseEntity<BookingResponseDto> payBooking(
-        @AuthenticationPrincipal UsersDetails usersDetails,
-        @PathVariable("bookingId") Long bookingId) {
+            @AuthenticationPrincipal UsersDetails usersDetails,
+            @PathVariable("bookingId") Long bookingId) {
         return ResponseEntity.ok(bookingService.payBooking(usersDetails, bookingId));
     }
 
     @GetMapping("/my")
-    @Operation(summary = "내 예매 내역 조회", description = "로그인한 유저의 예매 내역을 조회합니다. status 파라미터로 필터링 가능합니다.")
+    @Operation(
+            summary = "내 예매 내역 조회",
+            description = "로그인한 유저의 예매 내역을 조회합니다. status 파라미터로 필터링 가능합니다.")
     public ResponseEntity<List<BookingResponseDto>> getMyBookings(
-        @AuthenticationPrincipal UsersDetails usersDetails,
-        @RequestParam(required = false) BookingStatus status // ?status=CONFIRMED
-    ) {
+            @AuthenticationPrincipal UsersDetails usersDetails,
+            @RequestParam(required = false) BookingStatus status // ?status=CONFIRMED
+            ) {
         return ResponseEntity.ok(bookingService.getMyBookings(usersDetails, status));
     }
 }

--- a/src/main/java/com/DBP/ticketing_backend/domain/booking/controller/BookingController.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/booking/controller/BookingController.java
@@ -1,0 +1,63 @@
+package com.DBP.ticketing_backend.domain.booking.controller;
+
+import com.DBP.ticketing_backend.domain.auth.dto.UsersDetails;
+import com.DBP.ticketing_backend.domain.booking.dto.BookingRequestDto;
+import com.DBP.ticketing_backend.domain.booking.dto.BookingResponseDto;
+import com.DBP.ticketing_backend.domain.booking.enums.BookingStatus;
+import com.DBP.ticketing_backend.domain.booking.service.BookingService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/booking")
+@RequiredArgsConstructor
+@Tag(name = " 예매 api", description = "예매와 관련된 API 입니다.")
+public class BookingController {
+
+    private final BookingService bookingService;
+
+    @Operation(summary = "예매 생성", description = "이벤트 혹은 좌석 정보로 이벤트를 예매합니다.")
+    @PostMapping
+    public ResponseEntity<BookingResponseDto> createBooking(
+        @AuthenticationPrincipal UsersDetails usersDetails,
+        @RequestBody BookingRequestDto bookingRequestDto) {
+        return ResponseEntity.ok(bookingService.createBooking(usersDetails, bookingRequestDto));
+    }
+
+    @Operation(summary = "예매 취소", description = "결제 대기 혹은 예매 완료된 예매를 취소합니다.")
+    @DeleteMapping("/{bookingId}")
+    public ResponseEntity<BookingResponseDto> cancelBooking(
+        @AuthenticationPrincipal UsersDetails usersDetails,
+        @PathVariable("bookingId") Long bookingId) {
+        return ResponseEntity.ok(bookingService.cancelBooking(usersDetails, bookingId));
+    }
+
+    @Operation(summary = "결제", description = "결제를 통해 예매를 확정합니다.")
+    @PostMapping("/{bookingId}")
+    public ResponseEntity<BookingResponseDto> payBooking(
+        @AuthenticationPrincipal UsersDetails usersDetails,
+        @PathVariable("bookingId") Long bookingId) {
+        return ResponseEntity.ok(bookingService.payBooking(usersDetails, bookingId));
+    }
+
+    @GetMapping("/my")
+    @Operation(summary = "내 예매 내역 조회", description = "로그인한 유저의 예매 내역을 조회합니다. status 파라미터로 필터링 가능합니다.")
+    public ResponseEntity<List<BookingResponseDto>> getMyBookings(
+        @AuthenticationPrincipal UsersDetails usersDetails,
+        @RequestParam(required = false) BookingStatus status // ?status=CONFIRMED
+    ) {
+        return ResponseEntity.ok(bookingService.getMyBookings(usersDetails, status));
+    }
+}

--- a/src/main/java/com/DBP/ticketing_backend/domain/booking/dto/BookingRequestDto.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/booking/dto/BookingRequestDto.java
@@ -10,5 +10,4 @@ public class BookingRequestDto {
 
     // 스탠딩/자유석 예매 시 필수 (빈자리 자동 배정용)
     private Long eventId;
-
 }

--- a/src/main/java/com/DBP/ticketing_backend/domain/booking/dto/BookingRequestDto.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/booking/dto/BookingRequestDto.java
@@ -1,0 +1,14 @@
+package com.DBP.ticketing_backend.domain.booking.dto;
+
+import lombok.Data;
+
+@Data
+public class BookingRequestDto {
+
+    // 지정석 예매 시 필수
+    private Long seatId;
+
+    // 스탠딩/자유석 예매 시 필수 (빈자리 자동 배정용)
+    private Long eventId;
+
+}

--- a/src/main/java/com/DBP/ticketing_backend/domain/booking/dto/BookingResponseDto.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/booking/dto/BookingResponseDto.java
@@ -1,0 +1,45 @@
+package com.DBP.ticketing_backend.domain.booking.dto;
+
+import com.DBP.ticketing_backend.domain.booking.entity.Booking;
+import com.DBP.ticketing_backend.domain.booking.enums.BookingStatus;
+import com.DBP.ticketing_backend.domain.event.enums.SeatForm;
+import com.DBP.ticketing_backend.domain.seat.entity.Seat;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class BookingResponseDto {
+
+    private Long bookingId;
+    private String eventName;   // 이벤트명
+
+    // 좌석 정보
+    private String section;     // 구역 (예: A구역)
+    private Integer seatRow;    // 행
+    private Integer seatCol;    // 열
+
+    private Integer price;      // 가격
+    private BookingStatus status; // 상태 (PENDING)
+
+    public static BookingResponseDto from(Booking booking, Seat seat) {
+
+        SeatForm seatForm = seat.getEvent().getSeatForm();
+        boolean isAssigned = (seatForm == SeatForm.ASSIGNED);
+
+        return BookingResponseDto.builder()
+            .bookingId(booking.getBookingId())
+            // Seat를 통해 Event와 Template 정보에 접근
+            .eventName(seat.getEvent().getEventName())
+            .section(seat.getTemplate().getSection())
+            // 지정석인 경우에만 행과 열 정보를 포함
+            .seatRow(isAssigned ? seat.getTemplate().getRow() : null)
+            .seatCol(isAssigned ? seat.getTemplate().getColumn() : null)
+            .price(booking.getTotalPrice())
+            .status(booking.getStatus())
+            .build();
+    }
+
+}

--- a/src/main/java/com/DBP/ticketing_backend/domain/booking/dto/BookingResponseDto.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/booking/dto/BookingResponseDto.java
@@ -5,6 +5,7 @@ import com.DBP.ticketing_backend.domain.booking.enums.BookingStatus;
 import com.DBP.ticketing_backend.domain.event.enums.SeatForm;
 import com.DBP.ticketing_backend.domain.seat.entity.Seat;
 import com.fasterxml.jackson.annotation.JsonInclude;
+
 import lombok.Builder;
 import lombok.Data;
 
@@ -14,14 +15,14 @@ import lombok.Data;
 public class BookingResponseDto {
 
     private Long bookingId;
-    private String eventName;   // 이벤트명
+    private String eventName; // 이벤트명
 
     // 좌석 정보
-    private String section;     // 구역 (예: A구역)
-    private Integer seatRow;    // 행
-    private Integer seatCol;    // 열
+    private String section; // 구역 (예: A구역)
+    private Integer seatRow; // 행
+    private Integer seatCol; // 열
 
-    private Integer price;      // 가격
+    private Integer price; // 가격
     private BookingStatus status; // 상태 (PENDING)
 
     public static BookingResponseDto from(Booking booking, Seat seat) {
@@ -30,16 +31,15 @@ public class BookingResponseDto {
         boolean isAssigned = (seatForm == SeatForm.ASSIGNED);
 
         return BookingResponseDto.builder()
-            .bookingId(booking.getBookingId())
-            // Seat를 통해 Event와 Template 정보에 접근
-            .eventName(seat.getEvent().getEventName())
-            .section(seat.getTemplate().getSection())
-            // 지정석인 경우에만 행과 열 정보를 포함
-            .seatRow(isAssigned ? seat.getTemplate().getRow() : null)
-            .seatCol(isAssigned ? seat.getTemplate().getColumn() : null)
-            .price(booking.getTotalPrice())
-            .status(booking.getStatus())
-            .build();
+                .bookingId(booking.getBookingId())
+                // Seat를 통해 Event와 Template 정보에 접근
+                .eventName(seat.getEvent().getEventName())
+                .section(seat.getTemplate().getSection())
+                // 지정석인 경우에만 행과 열 정보를 포함
+                .seatRow(isAssigned ? seat.getTemplate().getRow() : null)
+                .seatCol(isAssigned ? seat.getTemplate().getColumn() : null)
+                .price(booking.getTotalPrice())
+                .status(booking.getStatus())
+                .build();
     }
-
 }

--- a/src/main/java/com/DBP/ticketing_backend/domain/booking/entity/Booking.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/booking/entity/Booking.java
@@ -47,4 +47,11 @@ public class Booking extends BaseEntity {
         this.status = status != null ? status : BookingStatus.PENDING;
         this.totalPrice = totalPrice;
     }
+
+    public void updateStatus(BookingStatus status) {
+        if (status == null) {
+            throw new IllegalArgumentException("예약 상태는 null일 수 없습니다.");
+        }
+        this.status = status;
+    }
 }

--- a/src/main/java/com/DBP/ticketing_backend/domain/booking/repository/BookingRepository.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/booking/repository/BookingRepository.java
@@ -3,9 +3,11 @@ package com.DBP.ticketing_backend.domain.booking.repository;
 import com.DBP.ticketing_backend.domain.booking.entity.Booking;
 import com.DBP.ticketing_backend.domain.booking.enums.BookingStatus;
 import com.DBP.ticketing_backend.domain.users.entity.Users;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
 import java.time.LocalDateTime;
 import java.util.List;
-import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BookingRepository extends JpaRepository<Booking, Long> {
 
@@ -16,5 +18,4 @@ public interface BookingRepository extends JpaRepository<Booking, Long> {
     List<Booking> findAllByUsersAndStatusOrderByCreatedAtDesc(Users users, BookingStatus status);
 
     List<Booking> findByStatusAndCreatedAtBefore(BookingStatus status, LocalDateTime threshold);
-
 }

--- a/src/main/java/com/DBP/ticketing_backend/domain/booking/repository/BookingRepository.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/booking/repository/BookingRepository.java
@@ -1,0 +1,20 @@
+package com.DBP.ticketing_backend.domain.booking.repository;
+
+import com.DBP.ticketing_backend.domain.booking.entity.Booking;
+import com.DBP.ticketing_backend.domain.booking.enums.BookingStatus;
+import com.DBP.ticketing_backend.domain.users.entity.Users;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BookingRepository extends JpaRepository<Booking, Long> {
+
+    // 내 예약 전체 조회 (최신순)
+    List<Booking> findAllByUsersOrderByCreatedAtDesc(Users users);
+
+    // 내 예약 상태별 조회 (최신순)
+    List<Booking> findAllByUsersAndStatusOrderByCreatedAtDesc(Users users, BookingStatus status);
+
+    List<Booking> findByStatusAndCreatedAtBefore(BookingStatus status, LocalDateTime threshold);
+
+}

--- a/src/main/java/com/DBP/ticketing_backend/domain/booking/schduler/BookingScheduler.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/booking/schduler/BookingScheduler.java
@@ -1,0 +1,22 @@
+package com.DBP.ticketing_backend.domain.booking.schduler;
+
+import com.DBP.ticketing_backend.domain.booking.service.BookingService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BookingScheduler {
+
+    private final BookingService bookingService;
+
+    @Scheduled(cron = "0 * * * * *") // 매 분 0초에 실행
+    public void autoCancelUnpaidBookings() {
+        log.info("결제 미진행 예약 자동 취소 스케줄러 실행");
+        bookingService.cancelExpiredBookings();
+    }
+
+}

--- a/src/main/java/com/DBP/ticketing_backend/domain/booking/schduler/BookingScheduler.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/booking/schduler/BookingScheduler.java
@@ -1,8 +1,10 @@
 package com.DBP.ticketing_backend.domain.booking.schduler;
 
 import com.DBP.ticketing_backend.domain.booking.service.BookingService;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -18,5 +20,4 @@ public class BookingScheduler {
         log.info("결제 미진행 예약 자동 취소 스케줄러 실행");
         bookingService.cancelExpiredBookings();
     }
-
 }

--- a/src/main/java/com/DBP/ticketing_backend/domain/booking/service/BookingService.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/booking/service/BookingService.java
@@ -1,0 +1,267 @@
+package com.DBP.ticketing_backend.domain.booking.service;
+
+import com.DBP.ticketing_backend.domain.auth.dto.UsersDetails;
+import com.DBP.ticketing_backend.domain.bookedseat.entity.BookedSeat;
+import com.DBP.ticketing_backend.domain.bookedseat.repository.BookedSeatRepository;
+import com.DBP.ticketing_backend.domain.bookedseathistory.entity.BookedSeatHistory;
+import com.DBP.ticketing_backend.domain.bookedseathistory.repository.BookedSeatHistoryRepository;
+import com.DBP.ticketing_backend.domain.booking.dto.BookingRequestDto;
+import com.DBP.ticketing_backend.domain.booking.dto.BookingResponseDto;
+import com.DBP.ticketing_backend.domain.booking.entity.Booking;
+import com.DBP.ticketing_backend.domain.booking.enums.BookingStatus;
+import com.DBP.ticketing_backend.domain.booking.repository.BookingRepository;
+import com.DBP.ticketing_backend.domain.event.entity.Event;
+import com.DBP.ticketing_backend.domain.event.enums.EventStatus;
+import com.DBP.ticketing_backend.domain.event.enums.SeatForm;
+import com.DBP.ticketing_backend.domain.event.repository.EventRepository;
+import com.DBP.ticketing_backend.domain.seat.entity.Seat;
+import com.DBP.ticketing_backend.domain.seat.enums.SeatStatus;
+import com.DBP.ticketing_backend.domain.seat.repository.SeatRepository;
+import com.DBP.ticketing_backend.domain.users.entity.Users;
+import com.DBP.ticketing_backend.domain.users.repository.UsersRepository;
+import com.DBP.ticketing_backend.global.exception.CustomException;
+import com.DBP.ticketing_backend.global.exception.ErrorCode;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class BookingService {
+
+    private final UsersRepository usersRepository;
+    private final EventRepository eventRepository;
+    private final SeatRepository seatRepository;
+    private final BookingRepository bookingRepository;
+    private final BookedSeatRepository bookedSeatRepository;
+    private final BookedSeatHistoryRepository bookedSeatHistoryRepository;
+
+    @Transactional
+    public BookingResponseDto createBooking(UsersDetails usersDetails, BookingRequestDto bookingRequestDto) {
+
+        // 유저 조회
+        Users user = usersRepository.findById(usersDetails.getUserId())
+            .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        // 이벤트 조회
+        Long eventId = bookingRequestDto.getEventId();
+        Event event = eventRepository.findById(eventId)
+            .orElseThrow(() -> new CustomException(ErrorCode.EVENT_NOT_FOUND));
+
+        // 예매 가능 시간 및 상태 확인
+        validateTicketingTime(event);
+
+        // 좌석 유형 확인
+        SeatForm seatForm = event.getSeatForm();
+
+        Seat seat;
+
+        // 지정석의 경우
+        if (seatForm == SeatForm.ASSIGNED) {
+            if (bookingRequestDto.getSeatId() == null) {
+                throw new CustomException(ErrorCode.INVALID_REQUEST);
+            }
+
+            seat = seatRepository.findByIdWithLock(bookingRequestDto.getSeatId())
+                .orElseThrow(() -> new CustomException(ErrorCode.SEAT_NOT_FOUND));
+
+            // 요청한 좌석의 이벤트와 일치하는지 확인
+            if (!seat.getEvent().getEventId().equals(eventId)) {
+                throw new CustomException(ErrorCode.INVALID_REQUEST);
+            }
+        // 자유석, 스탠딩석의 경우
+        } else {
+            seat = seatRepository.findFirstByEvent_EventIdAndStatus(eventId, SeatStatus.AVAILABLE)
+                .orElseThrow(() -> new CustomException(ErrorCode.SOLD_OUT));
+        }
+
+        // 좌석 상태 확인 및 업데이트
+        if (seat.getStatus() != SeatStatus.AVAILABLE) {
+            throw new CustomException(ErrorCode.ALREADY_RESERVED);
+        }
+        seat.updateStatus(SeatStatus.RESERVED);
+
+        // 예약 생성
+        Booking booking = Booking.builder()
+            .users(user)
+            .status(BookingStatus.PENDING) // 초기 상태: 결제 대기
+            .totalPrice(seat.getPrice())
+            .build();
+        Booking savedBooking = bookingRepository.save(booking);
+
+        // 예약된 좌석 정보 생성
+        BookedSeat bookedSeat = BookedSeat.builder()
+            .booking(savedBooking)
+            .seat(seat)
+            .build();
+        BookedSeat savedBookedSeat = bookedSeatRepository.save(bookedSeat);
+
+        // 예약된 좌석 이력 생성
+        BookedSeatHistory history = BookedSeatHistory.builder()
+            .bookedSeat(savedBookedSeat)
+            .booking(savedBooking)
+            .previousStatus(null) // 최초 생성이므로 이전 상태 없음
+            .currentStatus(BookingStatus.PENDING)
+            .build();
+
+        bookedSeatHistoryRepository.save(history);
+
+        return BookingResponseDto.from(savedBooking, seat);
+    }
+
+    @Transactional
+    public BookingResponseDto cancelBooking(UsersDetails usersDetails, Long bookingId) {
+
+        Booking booking = bookingRepository.findById(bookingId)
+            .orElseThrow(() -> new CustomException(ErrorCode.BOOKING_NOT_FOUND));
+
+        // 예약한 유저와 요청한 유저가 같은지 확인
+        if (!booking.getUsers().getUserId().equals(usersDetails.getUserId())) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED_ACCESS);
+        }
+
+        BookedSeat bookedSeat = bookedSeatRepository.findByBooking(booking)
+            .orElseThrow(() -> new CustomException(ErrorCode.SEAT_NOT_FOUND));
+
+        // 상태에 따른 분기 처리
+        if (booking.getStatus() == BookingStatus.PENDING) {
+            cancelPendingBooking(booking, bookedSeat);
+        } else if (booking.getStatus() == BookingStatus.CONFIRMED) {
+            cancelConfirmedBooking(booking, bookedSeat);
+        } else {
+            throw new CustomException(ErrorCode.INVALID_BOOKING_STATUS);
+        }
+        return BookingResponseDto.from(booking, bookedSeat.getSeat());
+    }
+
+    private void cancelConfirmedBooking(Booking booking, BookedSeat bookedSeat) {
+
+        Seat seat = bookedSeat.getSeat();
+        seat.updateStatus(SeatStatus.AVAILABLE);
+
+        // 상태 변경 및 히스토리 저장
+        changeBookingStatusWithHistory(booking, bookedSeat, BookingStatus.CANCELLED);
+    }
+
+    private void cancelPendingBooking(Booking booking, BookedSeat bookedSeat) {
+
+        Seat seat = bookedSeat.getSeat();
+        seat.updateStatus(SeatStatus.AVAILABLE);
+
+        // 상태 변경 및 히스토리 저장
+        changeBookingStatusWithHistory(booking, bookedSeat, BookingStatus.CANCELLED);
+    }
+
+    private void changeBookingStatusWithHistory(Booking booking, BookedSeat bookedSeat, BookingStatus newStatus) {
+        // 1. 이전 상태 기록
+        BookingStatus previousStatus = booking.getStatus();
+
+        // 2. 상태 변경
+        booking.updateStatus(newStatus);
+
+        // 3. 히스토리 저장
+        BookedSeatHistory history = BookedSeatHistory.builder()
+            .bookedSeat(bookedSeat)
+            .booking(booking)
+            .previousStatus(previousStatus) // 변경 전 상태 (예: CONFIRMED)
+            .currentStatus(newStatus)     // 변경 후 상태 (예: CANCELLED)
+            .build();
+
+        bookedSeatHistoryRepository.save(history);
+    }
+
+    @Transactional
+    public BookingResponseDto payBooking(UsersDetails usersDetails, Long bookingId) {
+
+        // 예약 조회
+        Booking booking = bookingRepository.findById(bookingId)
+            .orElseThrow(() -> new CustomException(ErrorCode.BOOKING_NOT_FOUND));
+
+        // 예약한 유저와 요청한 유저가 같은지 확인
+        if (!booking.getUsers().getUserId().equals(usersDetails.getUserId())) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED_ACCESS);
+        }
+
+        if (booking.getStatus() != BookingStatus.PENDING) {
+            // 이미 결제되었거나, 취소된 예약은 결제 불가
+            throw new CustomException(ErrorCode.INVALID_BOOKING_STATUS);
+        }
+
+        // 예약된 좌석 조회
+        BookedSeat bookedSeat = bookedSeatRepository.findByBooking(booking)
+            .orElseThrow(() -> new CustomException(ErrorCode.SEAT_NOT_FOUND));
+
+        Seat seat = bookedSeat.getSeat();
+
+        if (seat.getStatus() != SeatStatus.RESERVED) {
+            throw new CustomException(ErrorCode.INVALID_SEAT_STATUS);
+            // "결제 가능한 좌석 상태가 아닙니다."
+        }
+
+        // 좌석 상태를 SOLD로 업데이트
+        seat.updateStatus(SeatStatus.SOLD);
+        changeBookingStatusWithHistory(booking, bookedSeat, BookingStatus.CONFIRMED);
+
+        return BookingResponseDto.from(booking, seat);
+    }
+
+    private void validateTicketingTime(Event event) {
+        // 1. 시간 체크: 현재 시간이 예매 시작 시간보다 이전이면 에러
+        if (LocalDateTime.now().isBefore(event.getTicketingStartAt())) {
+            throw new CustomException(ErrorCode.TICKETING_NOT_OPEN);
+        }
+
+        // 2. 상태 체크: 이벤트 상태가 OPEN(예매 중)이 아니면 에러
+        if (event.getStatus() != EventStatus.OPEN) {
+            throw new CustomException(ErrorCode.TICKETING_CLOSED);
+        }
+    }
+
+    @Transactional(readOnly = true) // 조회 전용 최적화
+    public List<BookingResponseDto> getMyBookings(UsersDetails usersDetails, BookingStatus status) {
+
+        Users user = usersRepository.findById(usersDetails.getUserId())
+            .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        List<Booking> bookings;
+
+        if (status == null) {
+            bookings = bookingRepository.findAllByUsersOrderByCreatedAtDesc(user);
+        } else {
+            bookings = bookingRepository.findAllByUsersAndStatusOrderByCreatedAtDesc(user, status);
+        }
+
+        // Entity -> DTO 변환
+        return bookings.stream()
+            .map(booking -> {
+                // BookedSeat를 통해 Seat 정보 가져오기
+                BookedSeat bookedSeat = bookedSeatRepository.findByBooking(booking)
+                    .orElseThrow(() -> new CustomException(ErrorCode.SEAT_NOT_FOUND));
+
+                return BookingResponseDto.from(booking, bookedSeat.getSeat());
+            })
+            .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void cancelExpiredBookings() {
+        // 기준 시간 설정 (현재 시간 - 5분)
+        LocalDateTime fiveMinutesAgo = LocalDateTime.now().minusMinutes(5);
+
+        // 만료된 예약들 조회 (PENDING 상태 & 5분 지남)
+        List<Booking> expiredBookings = bookingRepository.findByStatusAndCreatedAtBefore(
+            BookingStatus.PENDING,
+            fiveMinutesAgo
+        );
+
+        // 하나씩 취소 처리
+        for (Booking booking : expiredBookings) {
+            BookedSeat bookedSeat = bookedSeatRepository.findByBooking(booking)
+                .orElseThrow(() -> new CustomException(ErrorCode.SEAT_NOT_FOUND));
+            cancelPendingBooking(booking, bookedSeat);
+        }
+    }
+}

--- a/src/main/java/com/DBP/ticketing_backend/domain/event/service/EventService.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/event/service/EventService.java
@@ -7,6 +7,7 @@ import com.DBP.ticketing_backend.domain.event.dto.EventDetailResponseDto;
 import com.DBP.ticketing_backend.domain.event.dto.EventListResponseDto;
 import com.DBP.ticketing_backend.domain.event.entity.Event;
 import com.DBP.ticketing_backend.domain.event.enums.EventStatus;
+import com.DBP.ticketing_backend.domain.event.enums.SeatForm;
 import com.DBP.ticketing_backend.domain.event.repository.EventRepository;
 import com.DBP.ticketing_backend.domain.host.entity.Host;
 import com.DBP.ticketing_backend.domain.host.repository.HostRepository;
@@ -61,9 +62,10 @@ public class EventService {
                         .findById(requestDto.getPlaceId())
                         .orElseThrow(() -> new CustomException(ErrorCode.PLACE_NOT_FOUND));
 
-        if (requestDto.getTicketingStartAt().isAfter(requestDto.getDate())) {
-            throw new CustomException(ErrorCode.INVALID_TICKET_OPEN_TIME);
-            // ErrorCode에 "예매 오픈 시간은 공연 시간보다 빨라야 합니다." 추가 필요
+        if (requestDto.getTicketingStartAt().getMinute() != 0 ||
+            requestDto.getTicketingStartAt().getSecond() != 0) {
+            // ErrorCode에 "예매 오픈은 정각 단위로만 설정 가능합니다." 추가 필요 (예: ONLY_ON_THE_HOUR)
+            throw new CustomException(ErrorCode.ONLY_ON_THE_HOUR);
         }
 
         Event event =
@@ -83,43 +85,48 @@ public class EventService {
         List<SeatTemplate> templates = seatTemplateRepository.findAllByPlace(place);
 
         if (templates.isEmpty()) {
-            throw new CustomException(ErrorCode.TEMPLATE_NOT_FOUND);
+            throw new CustomException(ErrorCode.TEMPLATE_NOT_FOUND); // "좌석 템플릿이 존재하지 않습니다."
         }
-
-        Map<String, SectionSetting> settingMap =
-                requestDto.getSeatSettings().stream()
-                        .collect(
-                                Collectors.toMap(
-                                        CreateEventRequestDto.SectionSetting::getSectionName,
-                                        setting -> setting));
 
         List<Seat> seatsToSave = new ArrayList<>();
 
-        for (SeatTemplate template : templates) {
-            String sectionName = template.getSection();
+        if (requestDto.getSeatForm() == SeatForm.ASSIGNED) {
+            // 지정석: 구역 이름(Key)으로 매핑
+            Map<String, CreateEventRequestDto.SectionSetting> settingMap = requestDto.getSeatSettings().stream()
+                .collect(Collectors.toMap(CreateEventRequestDto.SectionSetting::getSectionName, s -> s));
 
-            CreateEventRequestDto.SectionSetting setting = settingMap.get(sectionName);
+            for (SeatTemplate template : templates) {
+                CreateEventRequestDto.SectionSetting setting = settingMap.get(template.getSection());
+                if (setting == null) throw new CustomException(ErrorCode.SECTION_SETTING_MISSING);
 
-            if (setting == null) {
-                throw new CustomException(
-                        ErrorCode.SECTION_SETTING_MISSING); // "해당 구역의 가격 설정이 없습니다."
+                seatsToSave.add(createSeatEntity(savedEvent, template, setting));
             }
+        } else {
+            // 스탠딩/자유석: "대표 설정 하나"를 모든 템플릿에 일괄 적용
+            // 좌석 레벨과 가격을 통일
+            if (requestDto.getSeatSettings().isEmpty()) {
+                throw new CustomException(ErrorCode.SECTION_SETTING_MISSING);
+            }
+            CreateEventRequestDto.SectionSetting commonSetting = requestDto.getSeatSettings().get(0);
 
-            Seat seat =
-                    Seat.builder()
-                            .event(savedEvent)
-                            .template(template)
-                            .level(setting.getSeatLevel())
-                            .price(setting.getPrice())
-                            .status(SeatStatus.AVAILABLE)
-                            .build();
-
-            seatsToSave.add(seat);
+            for (SeatTemplate template : templates) {
+                // 구역 이름 확인 안 함! 무조건 commonSetting 적용
+                seatsToSave.add(createSeatEntity(savedEvent, template, commonSetting));
+            }
         }
 
         seatRepository.saveAll(seatsToSave);
-
         return savedEvent.getEventId();
+    }
+
+    private Seat createSeatEntity(Event event, SeatTemplate template, CreateEventRequestDto.SectionSetting setting) {
+        return Seat.builder()
+            .event(event)
+            .template(template)
+            .level(setting.getSeatLevel())
+            .price(setting.getPrice())
+            .status(SeatStatus.AVAILABLE)
+            .build();
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/DBP/ticketing_backend/domain/event/service/EventService.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/event/service/EventService.java
@@ -2,7 +2,6 @@ package com.DBP.ticketing_backend.domain.event.service;
 
 import com.DBP.ticketing_backend.domain.auth.dto.UsersDetails;
 import com.DBP.ticketing_backend.domain.event.dto.CreateEventRequestDto;
-import com.DBP.ticketing_backend.domain.event.dto.CreateEventRequestDto.SectionSetting;
 import com.DBP.ticketing_backend.domain.event.dto.EventDetailResponseDto;
 import com.DBP.ticketing_backend.domain.event.dto.EventListResponseDto;
 import com.DBP.ticketing_backend.domain.event.entity.Event;
@@ -62,8 +61,8 @@ public class EventService {
                         .findById(requestDto.getPlaceId())
                         .orElseThrow(() -> new CustomException(ErrorCode.PLACE_NOT_FOUND));
 
-        if (requestDto.getTicketingStartAt().getMinute() != 0 ||
-            requestDto.getTicketingStartAt().getSecond() != 0) {
+        if (requestDto.getTicketingStartAt().getMinute() != 0
+                || requestDto.getTicketingStartAt().getSecond() != 0) {
             // ErrorCode에 "예매 오픈은 정각 단위로만 설정 가능합니다." 추가 필요 (예: ONLY_ON_THE_HOUR)
             throw new CustomException(ErrorCode.ONLY_ON_THE_HOUR);
         }
@@ -92,11 +91,16 @@ public class EventService {
 
         if (requestDto.getSeatForm() == SeatForm.ASSIGNED) {
             // 지정석: 구역 이름(Key)으로 매핑
-            Map<String, CreateEventRequestDto.SectionSetting> settingMap = requestDto.getSeatSettings().stream()
-                .collect(Collectors.toMap(CreateEventRequestDto.SectionSetting::getSectionName, s -> s));
+            Map<String, CreateEventRequestDto.SectionSetting> settingMap =
+                    requestDto.getSeatSettings().stream()
+                            .collect(
+                                    Collectors.toMap(
+                                            CreateEventRequestDto.SectionSetting::getSectionName,
+                                            s -> s));
 
             for (SeatTemplate template : templates) {
-                CreateEventRequestDto.SectionSetting setting = settingMap.get(template.getSection());
+                CreateEventRequestDto.SectionSetting setting =
+                        settingMap.get(template.getSection());
                 if (setting == null) throw new CustomException(ErrorCode.SECTION_SETTING_MISSING);
 
                 seatsToSave.add(createSeatEntity(savedEvent, template, setting));
@@ -107,7 +111,8 @@ public class EventService {
             if (requestDto.getSeatSettings().isEmpty()) {
                 throw new CustomException(ErrorCode.SECTION_SETTING_MISSING);
             }
-            CreateEventRequestDto.SectionSetting commonSetting = requestDto.getSeatSettings().get(0);
+            CreateEventRequestDto.SectionSetting commonSetting =
+                    requestDto.getSeatSettings().get(0);
 
             for (SeatTemplate template : templates) {
                 // 구역 이름 확인 안 함! 무조건 commonSetting 적용
@@ -119,14 +124,15 @@ public class EventService {
         return savedEvent.getEventId();
     }
 
-    private Seat createSeatEntity(Event event, SeatTemplate template, CreateEventRequestDto.SectionSetting setting) {
+    private Seat createSeatEntity(
+            Event event, SeatTemplate template, CreateEventRequestDto.SectionSetting setting) {
         return Seat.builder()
-            .event(event)
-            .template(template)
-            .level(setting.getSeatLevel())
-            .price(setting.getPrice())
-            .status(SeatStatus.AVAILABLE)
-            .build();
+                .event(event)
+                .template(template)
+                .level(setting.getSeatLevel())
+                .price(setting.getPrice())
+                .status(SeatStatus.AVAILABLE)
+                .build();
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/DBP/ticketing_backend/domain/seat/controller/SeatController.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/seat/controller/SeatController.java
@@ -2,15 +2,19 @@ package com.DBP.ticketing_backend.domain.seat.controller;
 
 import com.DBP.ticketing_backend.domain.seat.dto.SeatResponseDto;
 import com.DBP.ticketing_backend.domain.seat.service.SeatService;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.List;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/seat")
@@ -25,5 +29,4 @@ public class SeatController {
     public ResponseEntity<List<SeatResponseDto>> getSeats(@PathVariable Long eventId) {
         return ResponseEntity.ok(seatService.getSeatsByEvent(eventId));
     }
-
 }

--- a/src/main/java/com/DBP/ticketing_backend/domain/seat/controller/SeatController.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/seat/controller/SeatController.java
@@ -1,0 +1,29 @@
+package com.DBP.ticketing_backend.domain.seat.controller;
+
+import com.DBP.ticketing_backend.domain.seat.dto.SeatResponseDto;
+import com.DBP.ticketing_backend.domain.seat.service.SeatService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/seat")
+@RequiredArgsConstructor
+@Tag(name = " 좌석 api", description = "좌석과 관련된 API 입니다.")
+public class SeatController {
+
+    private final SeatService seatService;
+
+    @GetMapping("/{eventId}")
+    @Operation(summary = "좌석 조회", description = "특정 이벤트의 전체 좌석 상태를 조회합니다.")
+    public ResponseEntity<List<SeatResponseDto>> getSeats(@PathVariable Long eventId) {
+        return ResponseEntity.ok(seatService.getSeatsByEvent(eventId));
+    }
+
+}

--- a/src/main/java/com/DBP/ticketing_backend/domain/seat/dto/SeatResponseDto.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/seat/dto/SeatResponseDto.java
@@ -1,0 +1,30 @@
+package com.DBP.ticketing_backend.domain.seat.dto;
+
+import com.DBP.ticketing_backend.domain.seat.entity.Seat;
+import com.DBP.ticketing_backend.domain.seat.enums.SeatStatus;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class SeatResponseDto {
+    private Long seatId;
+    private String section;      // 구역 (A구역)
+    private Integer row;         // 행
+    private Integer col;         // 열
+    private String seatLevel;    // 등급 (VIP, R)
+    private Integer price;       // 가격
+    private SeatStatus status;   // 판매 가능 여부
+
+    public static SeatResponseDto from(Seat seat) {
+        return SeatResponseDto.builder()
+            .seatId(seat.getSeatId())
+            .section(seat.getTemplate().getSection())
+            .row(seat.getTemplate().getRow())
+            .col(seat.getTemplate().getColumn())
+            .seatLevel(seat.getLevel().toString())
+            .price(seat.getPrice())
+            .status(seat.getStatus())
+            .build();
+    }
+}

--- a/src/main/java/com/DBP/ticketing_backend/domain/seat/dto/SeatResponseDto.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/seat/dto/SeatResponseDto.java
@@ -2,6 +2,7 @@ package com.DBP.ticketing_backend.domain.seat.dto;
 
 import com.DBP.ticketing_backend.domain.seat.entity.Seat;
 import com.DBP.ticketing_backend.domain.seat.enums.SeatStatus;
+
 import lombok.Builder;
 import lombok.Data;
 
@@ -9,22 +10,22 @@ import lombok.Data;
 @Builder
 public class SeatResponseDto {
     private Long seatId;
-    private String section;      // 구역 (A구역)
-    private Integer row;         // 행
-    private Integer col;         // 열
-    private String seatLevel;    // 등급 (VIP, R)
-    private Integer price;       // 가격
-    private SeatStatus status;   // 판매 가능 여부
+    private String section; // 구역 (A구역)
+    private Integer row; // 행
+    private Integer col; // 열
+    private String seatLevel; // 등급 (VIP, R)
+    private Integer price; // 가격
+    private SeatStatus status; // 판매 가능 여부
 
     public static SeatResponseDto from(Seat seat) {
         return SeatResponseDto.builder()
-            .seatId(seat.getSeatId())
-            .section(seat.getTemplate().getSection())
-            .row(seat.getTemplate().getRow())
-            .col(seat.getTemplate().getColumn())
-            .seatLevel(seat.getLevel().toString())
-            .price(seat.getPrice())
-            .status(seat.getStatus())
-            .build();
+                .seatId(seat.getSeatId())
+                .section(seat.getTemplate().getSection())
+                .row(seat.getTemplate().getRow())
+                .col(seat.getTemplate().getColumn())
+                .seatLevel(seat.getLevel().toString())
+                .price(seat.getPrice())
+                .status(seat.getStatus())
+                .build();
     }
 }

--- a/src/main/java/com/DBP/ticketing_backend/domain/seat/entity/Seat.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/seat/entity/Seat.java
@@ -60,4 +60,11 @@ public class Seat extends BaseEntity {
         this.price = price;
         this.status = status != null ? status : SeatStatus.AVAILABLE;
     }
+
+    public void updateStatus(SeatStatus status) {
+        if (status == null) {
+            throw new IllegalArgumentException("좌석 상태는 null일 수 없습니다.");
+        }
+        this.status = status;
+    }
 }

--- a/src/main/java/com/DBP/ticketing_backend/domain/seat/enums/SeatStatus.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/seat/enums/SeatStatus.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum SeatStatus {
     AVAILABLE("예매 가능", "예매 가능한 좌석"),
+    RESERVED("예약 중", "예약되었으나 결제 대기 중인 좌석"),
     SOLD("판매 완료", "결제 완료된 좌석"),
     UNAVAILABLE("판매 불가", "판매하지 않는 좌석");
 

--- a/src/main/java/com/DBP/ticketing_backend/domain/seat/repository/SeatRepository.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/seat/repository/SeatRepository.java
@@ -2,6 +2,23 @@ package com.DBP.ticketing_backend.domain.seat.repository;
 
 import com.DBP.ticketing_backend.domain.seat.entity.Seat;
 
+import com.DBP.ticketing_backend.domain.seat.enums.SeatStatus;
+import jakarta.persistence.LockModeType;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-public interface SeatRepository extends JpaRepository<Seat, Long> {}
+public interface SeatRepository extends JpaRepository<Seat, Long> {
+
+    @Query("SELECT s FROM Seat s WHERE s.event.eventId = :eventId ORDER BY s.level, s.template.row, s.template.column")
+    List<Seat> findAllByEventId(@Param("eventId") Long eventId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select s from Seat s where s.seatId = :seatId")
+    Optional<Seat> findByIdWithLock(Long seatId);
+
+    Optional<Seat> findFirstByEvent_EventIdAndStatus(Long eventId, SeatStatus seatStatus);
+}

--- a/src/main/java/com/DBP/ticketing_backend/domain/seat/repository/SeatRepository.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/seat/repository/SeatRepository.java
@@ -1,19 +1,23 @@
 package com.DBP.ticketing_backend.domain.seat.repository;
 
 import com.DBP.ticketing_backend.domain.seat.entity.Seat;
-
 import com.DBP.ticketing_backend.domain.seat.enums.SeatStatus;
+
 import jakarta.persistence.LockModeType;
-import java.util.List;
-import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface SeatRepository extends JpaRepository<Seat, Long> {
 
-    @Query("SELECT s FROM Seat s WHERE s.event.eventId = :eventId ORDER BY s.level, s.template.row, s.template.column")
+    @Query(
+            "SELECT s FROM Seat s WHERE s.event.eventId = :eventId ORDER BY s.level,"
+                + " s.template.row, s.template.column")
     List<Seat> findAllByEventId(@Param("eventId") Long eventId);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)

--- a/src/main/java/com/DBP/ticketing_backend/domain/seat/repository/SeatRepository.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/seat/repository/SeatRepository.java
@@ -17,7 +17,7 @@ public interface SeatRepository extends JpaRepository<Seat, Long> {
 
     @Query(
             "SELECT s FROM Seat s WHERE s.event.eventId = :eventId ORDER BY s.level,"
-                + " s.template.row, s.template.column")
+                    + " s.template.row, s.template.column")
     List<Seat> findAllByEventId(@Param("eventId") Long eventId);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)

--- a/src/main/java/com/DBP/ticketing_backend/domain/seat/service/SeatService.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/seat/service/SeatService.java
@@ -3,11 +3,14 @@ package com.DBP.ticketing_backend.domain.seat.service;
 import com.DBP.ticketing_backend.domain.seat.dto.SeatResponseDto;
 import com.DBP.ticketing_backend.domain.seat.entity.Seat;
 import com.DBP.ticketing_backend.domain.seat.repository.SeatRepository;
-import java.util.List;
-import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -21,9 +24,6 @@ public class SeatService {
         List<Seat> seats = seatRepository.findAllByEventId(eventId);
 
         // 2. DTO 변환
-        return seats.stream()
-            .map(SeatResponseDto::from)
-            .collect(Collectors.toList());
+        return seats.stream().map(SeatResponseDto::from).collect(Collectors.toList());
     }
-
 }

--- a/src/main/java/com/DBP/ticketing_backend/domain/seat/service/SeatService.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/seat/service/SeatService.java
@@ -1,0 +1,29 @@
+package com.DBP.ticketing_backend.domain.seat.service;
+
+import com.DBP.ticketing_backend.domain.seat.dto.SeatResponseDto;
+import com.DBP.ticketing_backend.domain.seat.entity.Seat;
+import com.DBP.ticketing_backend.domain.seat.repository.SeatRepository;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SeatService {
+
+    private final SeatRepository seatRepository;
+
+    @Transactional(readOnly = true)
+    public List<SeatResponseDto> getSeatsByEvent(Long eventId) {
+        // 1. 해당 이벤트의 모든 좌석 조회
+        List<Seat> seats = seatRepository.findAllByEventId(eventId);
+
+        // 2. DTO 변환
+        return seats.stream()
+            .map(SeatResponseDto::from)
+            .collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/com/DBP/ticketing_backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/DBP/ticketing_backend/global/config/SecurityConfig.java
@@ -43,7 +43,8 @@ public class SecurityConfig {
                                             "/api/auth/login", // 로그인
                                             "/api/auth/refresh", // 토큰 재발급
                                             "/api/events",
-                                            "/api/events/{eventId}")
+                                            "/api/events/{eventId}",
+                                            "/api/seat/**")
                                     .permitAll();
 
                             // 로그아웃은 인증 필요

--- a/src/main/java/com/DBP/ticketing_backend/global/exception/CustomException.java
+++ b/src/main/java/com/DBP/ticketing_backend/global/exception/CustomException.java
@@ -5,7 +5,10 @@ import lombok.Getter;
 @Getter
 public class CustomException extends RuntimeException {
 
-    int errorCode;
+    private final ErrorCode errorCode;
 
-    public CustomException(ErrorCode errorCode) {}
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
 }

--- a/src/main/java/com/DBP/ticketing_backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/DBP/ticketing_backend/global/exception/ErrorCode.java
@@ -12,6 +12,13 @@ public enum ErrorCode {
     NOT_AN_ACTIVATED_HOST(HttpStatus.BAD_REQUEST, "활성화된 호스트가 아닙니다."),
     INVALID_EMAIL_OR_PASSWORD(HttpStatus.BAD_REQUEST, "이메일 또는 비밀번호가 올바르지 않습니다."),
     INVALID_TICKET_OPEN_TIME(HttpStatus.BAD_REQUEST, "예매 오픈 시간은 공연 시간보다 빨라야 합니다."),
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    SOLD_OUT(HttpStatus.BAD_REQUEST, "매진된 공연입니다."),
+    ALREADY_RESERVED(HttpStatus.BAD_REQUEST, "이미 예약된 좌석입니다."),
+    INVALID_BOOKING_STATUS(HttpStatus.BAD_REQUEST, "유효하지 않은 예약 상태입니다."),
+    TICKETING_NOT_OPEN(HttpStatus.BAD_REQUEST, "예매가 오픈되지 않은 공연입니다."),
+    TICKETING_CLOSED(HttpStatus.BAD_REQUEST, "예매가 종료된 공연입니다."),
+    INVALID_SEAT_STATUS(HttpStatus.BAD_REQUEST, "유효하지 않은 좌석 상태입니다."),
 
     // 401 Unauthorized: 인증되지 않은 사용자
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요한 요청입니다."),
@@ -28,6 +35,8 @@ public enum ErrorCode {
     SECTION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 섹션을 찾을 수 없습니다."),
     SECTION_SETTING_MISSING(HttpStatus.NOT_FOUND, "섹션 설정이 누락되었습니다."),
     EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 공연을 찾을 수 없습니다."),
+    SEAT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 좌석을 찾을 수 없습니다."),
+    BOOKING_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 예약을 찾을 수 없습니다."),
 
     // 409 Conflict: 충돌
     DUPLICATE_MEMBER_EMAIL(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),

--- a/src/main/java/com/DBP/ticketing_backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/DBP/ticketing_backend/global/exception/ErrorCode.java
@@ -18,8 +18,7 @@ public enum ErrorCode {
     INVALID_BOOKING_STATUS(HttpStatus.BAD_REQUEST, "유효하지 않은 예약 상태입니다."),
     TICKETING_NOT_OPEN(HttpStatus.BAD_REQUEST, "예매가 오픈되지 않은 공연입니다."),
     TICKETING_CLOSED(HttpStatus.BAD_REQUEST, "예매가 종료된 공연입니다."),
-    INVALID_SEAT_STATUS(HttpStatus.BAD_REQUEST, "유효하지 않은 좌석 상태입니다."),
-
+    ONLY_ON_THE_HOUR(HttpStatus.BAD_REQUEST, "예매 오픈은 정각 단위로만 설정 가능합니다."),
     // 401 Unauthorized: 인증되지 않은 사용자
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요한 요청입니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),

--- a/src/main/java/com/DBP/ticketing_backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/DBP/ticketing_backend/global/exception/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
     UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "권한이 없는 접근입니다."),
+    INVALID_SEAT_STATUS(HttpStatus.UNAUTHORIZED, "유효하지 않은 좌석 상태입니다."),
 
     // 404 Not Found: 리소스를 찾을 수 없음
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자를 찾을 수 없습니다."),

--- a/src/main/java/com/DBP/ticketing_backend/global/exception/ErrorResponse.java
+++ b/src/main/java/com/DBP/ticketing_backend/global/exception/ErrorResponse.java
@@ -1,12 +1,13 @@
 package com.DBP.ticketing_backend.global.exception;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
+@AllArgsConstructor
 public class ErrorResponse {
-
     private final int status;
     private final String message;
 }

--- a/src/main/java/com/DBP/ticketing_backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/DBP/ticketing_backend/global/exception/GlobalExceptionHandler.java
@@ -3,14 +3,10 @@ package com.DBP.ticketing_backend.global.exception;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-
-import java.util.HashMap;
-import java.util.Map;
 import org.springframework.web.multipart.MultipartException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
@@ -20,32 +16,37 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleCustomException(CustomException ex) {
         ErrorCode errorCode = ex.getErrorCode();
 
-        return ResponseEntity
-            .status(errorCode.getStatus()) // ErrorCode의 HTTP 상태 코드 사용 (400, 401, 404 등)
-            .body(ErrorResponse.builder()
-                .status(errorCode.getStatus().value())
-                .message(errorCode.getMessage())
-                .build());
+        return ResponseEntity.status(
+                        errorCode.getStatus()) // ErrorCode의 HTTP 상태 코드 사용 (400, 401, 404 등)
+                .body(
+                        ErrorResponse.builder()
+                                .status(errorCode.getStatus().value())
+                                .message(errorCode.getMessage())
+                                .build());
     }
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ErrorResponse> handleValidationExceptions(MethodArgumentNotValidException ex) {
+    public ResponseEntity<ErrorResponse> handleValidationExceptions(
+            MethodArgumentNotValidException ex) {
 
         // 첫 번째 에러 메시지만 보여주기 (깔끔하게)
-        String errorMessage = ex.getBindingResult().getFieldErrors().stream()
-            .findFirst()
-            .map(FieldError::getDefaultMessage)
-            .orElse("입력값이 올바르지 않습니다.");
+        String errorMessage =
+                ex.getBindingResult().getFieldErrors().stream()
+                        .findFirst()
+                        .map(FieldError::getDefaultMessage)
+                        .orElse("입력값이 올바르지 않습니다.");
 
-        return ResponseEntity
-            .status(HttpStatus.BAD_REQUEST)
-            .body(ErrorResponse.builder()
-                .status(HttpStatus.BAD_REQUEST.value())
-                .message(errorMessage)
-                .build());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(
+                        ErrorResponse.builder()
+                                .status(HttpStatus.BAD_REQUEST.value())
+                                .message(errorMessage)
+                                .build());
     }
 
     @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException ex) {
+    public ResponseEntity<ErrorResponse> handleIllegalArgumentException(
+            IllegalArgumentException ex) {
         return buildErrorResponse(HttpStatus.BAD_REQUEST, ex.getMessage());
     }
 
@@ -55,12 +56,14 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(NoResourceFoundException.class)
-    public ResponseEntity<ErrorResponse> handleNoResourceFoundException(NoResourceFoundException ex) {
+    public ResponseEntity<ErrorResponse> handleNoResourceFoundException(
+            NoResourceFoundException ex) {
         return buildErrorResponse(HttpStatus.NOT_FOUND, ex.getMessage());
     }
 
     @ExceptionHandler(DataIntegrityViolationException.class)
-    public ResponseEntity<ErrorResponse> handleDataIntegrityViolationException(DataIntegrityViolationException ex) {
+    public ResponseEntity<ErrorResponse> handleDataIntegrityViolationException(
+            DataIntegrityViolationException ex) {
         return buildErrorResponse(HttpStatus.BAD_REQUEST, "중복된 데이터가 존재하거나 데이터 무결성 위반입니다.");
     }
 
@@ -71,11 +74,7 @@ public class GlobalExceptionHandler {
     }
 
     private ResponseEntity<ErrorResponse> buildErrorResponse(HttpStatus status, String message) {
-        return ResponseEntity
-            .status(status)
-            .body(ErrorResponse.builder()
-                .status(status.value())
-                .message(message)
-                .build());
+        return ResponseEntity.status(status)
+                .body(ErrorResponse.builder().status(status.value()).message(message).build());
     }
 }

--- a/src/main/java/com/DBP/ticketing_backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/DBP/ticketing_backend/global/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.DBP.ticketing_backend.global.exception;
 
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
@@ -10,26 +11,71 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.util.HashMap;
 import java.util.Map;
+import org.springframework.web.multipart.MultipartException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ErrorResponse> handleCustomException(CustomException ex) {
+        ErrorCode errorCode = ex.getErrorCode();
 
-    // MethodArgumentNotValidException 예외를 특별히 처리하는 메서드
+        return ResponseEntity
+            .status(errorCode.getStatus()) // ErrorCode의 HTTP 상태 코드 사용 (400, 401, 404 등)
+            .body(ErrorResponse.builder()
+                .status(errorCode.getStatus().value())
+                .message(errorCode.getMessage())
+                .build());
+    }
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<Map<String, String>> handleValidationExceptions(
-            MethodArgumentNotValidException ex) {
+    public ResponseEntity<ErrorResponse> handleValidationExceptions(MethodArgumentNotValidException ex) {
 
-        // 에러 메시지를 담을 Map 생성
-        Map<String, String> errors = new HashMap<>();
+        // 첫 번째 에러 메시지만 보여주기 (깔끔하게)
+        String errorMessage = ex.getBindingResult().getFieldErrors().stream()
+            .findFirst()
+            .map(FieldError::getDefaultMessage)
+            .orElse("입력값이 올바르지 않습니다.");
 
-        // 예외 결과(BindingResult)에서 모든 필드 에러(FieldError)를 가져옴
-        BindingResult bindingResult = ex.getBindingResult();
-        for (FieldError fieldError : bindingResult.getFieldErrors()) {
-            // 어떤 필드에서 에러가 났는지(field)와 DTO에 설정한 메시지(message)를 Map에 담음
-            errors.put(fieldError.getField(), fieldError.getDefaultMessage());
-        }
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(ErrorResponse.builder()
+                .status(HttpStatus.BAD_REQUEST.value())
+                .message(errorMessage)
+                .build());
+    }
 
-        // 400 Bad Request 상태 코드와 함께 에러 메시지를 담은 Map을 응답으로 보냄
-        return new ResponseEntity<>(errors, HttpStatus.BAD_REQUEST);
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException ex) {
+        return buildErrorResponse(HttpStatus.BAD_REQUEST, ex.getMessage());
+    }
+
+    @ExceptionHandler(MultipartException.class)
+    public ResponseEntity<ErrorResponse> handleMultipartException(MultipartException ex) {
+        return buildErrorResponse(HttpStatus.BAD_REQUEST, ex.getMessage());
+    }
+
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<ErrorResponse> handleNoResourceFoundException(NoResourceFoundException ex) {
+        return buildErrorResponse(HttpStatus.NOT_FOUND, ex.getMessage());
+    }
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<ErrorResponse> handleDataIntegrityViolationException(DataIntegrityViolationException ex) {
+        return buildErrorResponse(HttpStatus.BAD_REQUEST, "중복된 데이터가 존재하거나 데이터 무결성 위반입니다.");
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception ex) {
+        ex.printStackTrace(); // 서버 로그에 스택트레이스 남기기
+        return buildErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다.");
+    }
+
+    private ResponseEntity<ErrorResponse> buildErrorResponse(HttpStatus status, String message) {
+        return ResponseEntity
+            .status(status)
+            .body(ErrorResponse.builder()
+                .status(status.value())
+                .message(message)
+                .build());
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #13 

## 📝작업 내용
- 이벤트 아이디를 통해 좌석을 조회하는 API 구현
- 이벤트 아이디와 좌석 아이디로 좌석을 예매하는 API 구현
- 스탠딩/자율석인 경우 빈 첫 번째 자리로 배정 후 반환값에는 좌석정보 X
- 스탠딩/자율석인 경우 구역과 관계없이 모든 좌석 레벨과 가격을 0번째 템플릿으로 통일
- 예매 후에는 결제 대기로 바뀌며, 5분이 지나거나 취소를 하면 결제 취소 상태로 변경됨
- 결제는 단순 API를 통해 결제 완료 상태로만 바꿔줌 

## 📸 스크린샷 (선택)
<img width="2024" height="836" alt="image" src="https://github.com/user-attachments/assets/264ce53e-1dc3-494a-9200-5cfc5466c2b1" />


## 🧪 테스트 여부
- [ ] 테스트 코드를 작성함
- [ ] 테스트를 수행함

## 💬리뷰 요구사항(선택)
- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?