### PR TITLE
feat(17): 지정석 분산락 설정

### DIFF
--- a/src/main/java/com/DBP/ticketing_backend/domain/booking/controller/BookingController.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/booking/controller/BookingController.java
@@ -4,6 +4,7 @@ import com.DBP.ticketing_backend.domain.auth.dto.UsersDetails;
 import com.DBP.ticketing_backend.domain.booking.dto.BookingRequestDto;
 import com.DBP.ticketing_backend.domain.booking.dto.BookingResponseDto;
 import com.DBP.ticketing_backend.domain.booking.enums.BookingStatus;
+import com.DBP.ticketing_backend.domain.booking.facade.BookingFacade;
 import com.DBP.ticketing_backend.domain.booking.service.BookingService;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -31,13 +32,14 @@ import java.util.List;
 public class BookingController {
 
     private final BookingService bookingService;
+    private final BookingFacade bookingFacade;
 
     @Operation(summary = "예매 생성", description = "이벤트 혹은 좌석 정보로 이벤트를 예매합니다.")
     @PostMapping
     public ResponseEntity<BookingResponseDto> createBooking(
             @AuthenticationPrincipal UsersDetails usersDetails,
             @RequestBody BookingRequestDto bookingRequestDto) {
-        return ResponseEntity.ok(bookingService.createBooking(usersDetails, bookingRequestDto));
+        return ResponseEntity.ok(bookingFacade.createBooking(usersDetails, bookingRequestDto));
     }
 
     @Operation(summary = "예매 취소", description = "결제 대기 혹은 예매 완료된 예매를 취소합니다.")

--- a/src/main/java/com/DBP/ticketing_backend/domain/booking/dto/BookingRequestDto.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/booking/dto/BookingRequestDto.java
@@ -1,8 +1,10 @@
 package com.DBP.ticketing_backend.domain.booking.dto;
 
+import lombok.Builder;
 import lombok.Data;
 
 @Data
+@Builder
 public class BookingRequestDto {
 
     // 지정석 예매 시 필수

--- a/src/main/java/com/DBP/ticketing_backend/domain/booking/facade/BookingFacade.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/booking/facade/BookingFacade.java
@@ -1,0 +1,69 @@
+package com.DBP.ticketing_backend.domain.booking.facade;
+
+import com.DBP.ticketing_backend.domain.auth.dto.UsersDetails;
+import com.DBP.ticketing_backend.domain.booking.dto.BookingRequestDto;
+import com.DBP.ticketing_backend.domain.booking.dto.BookingResponseDto;
+import com.DBP.ticketing_backend.domain.booking.service.BookingService;
+import com.DBP.ticketing_backend.global.exception.CustomException;
+import com.DBP.ticketing_backend.global.exception.ErrorCode;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BookingFacade {
+
+    private final RedissonClient redissonClient;
+    private final BookingService bookingService;
+
+    public BookingResponseDto createBooking(UsersDetails usersDetails, BookingRequestDto requestDto) {
+
+        // 1. 지정석 예매인 경우 (seatId가 존재함) -> 분산 락 적용
+        if (requestDto.getSeatId() != null) {
+            return createAssignedBookingWithLock(usersDetails, requestDto);
+        }
+
+        // 2. 스탠딩/자유석 예매인 경우 -> 락 없이 서비스 호출 (추후 대기열/재고 차감 로직 적용 예정)
+        return bookingService.createBooking(usersDetails, requestDto);
+    }
+
+    private BookingResponseDto createAssignedBookingWithLock(UsersDetails usersDetails, BookingRequestDto requestDto) {
+        Long seatId = requestDto.getSeatId();
+
+        // 락 Key 생성 (유니크)
+        String lockKey = "lock:seat:" + seatId;
+        RLock lock = redissonClient.getLock(lockKey);
+
+        try {
+            // 락 획득 시도 (tryLock)
+            // waitTime (3초): 락을 얻기 위해 기다리는 시간 (3초 동안 못 얻으면 포기)
+            // leaseTime (10초): 락을 얻은 후 유지하는 시간 (10초 지나면 강제 반납 - 데드락 방지)
+            boolean available = lock.tryLock(3, 10, TimeUnit.SECONDS);
+
+            if (!available) {
+                log.warn("좌석 락 획득 실패 - seatId: {}", seatId);
+                throw new CustomException(ErrorCode.ALREADY_RESERVED); // "이미 처리 중인 좌석입니다."
+            }
+
+            log.info("좌석 락 획득 성공 - seatId: {}", seatId);
+
+            return bookingService.createBooking(usersDetails, requestDto);
+
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        } finally {
+            // 락 해제 (반드시 finally 블록에서 수행)
+            // isHeldByCurrentThread: 현재 스레드가 락을 잡고 있을 때만 해제 (남의 락 해제 방지)
+            if (lock.isHeldByCurrentThread()) {
+                lock.unlock();
+                log.info("좌석 락 해제 완료 - seatId: {}", seatId);
+            }
+        }
+    }
+
+}

--- a/src/main/java/com/DBP/ticketing_backend/domain/booking/facade/BookingFacade.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/booking/facade/BookingFacade.java
@@ -6,12 +6,15 @@ import com.DBP.ticketing_backend.domain.booking.dto.BookingResponseDto;
 import com.DBP.ticketing_backend.domain.booking.service.BookingService;
 import com.DBP.ticketing_backend.global.exception.CustomException;
 import com.DBP.ticketing_backend.global.exception.ErrorCode;
-import java.util.concurrent.TimeUnit;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @Component
@@ -21,7 +24,8 @@ public class BookingFacade {
     private final RedissonClient redissonClient;
     private final BookingService bookingService;
 
-    public BookingResponseDto createBooking(UsersDetails usersDetails, BookingRequestDto requestDto) {
+    public BookingResponseDto createBooking(
+            UsersDetails usersDetails, BookingRequestDto requestDto) {
 
         // 1. 지정석 예매인 경우 (seatId가 존재함) -> 분산 락 적용
         if (requestDto.getSeatId() != null) {
@@ -32,7 +36,8 @@ public class BookingFacade {
         return bookingService.createBooking(usersDetails, requestDto);
     }
 
-    private BookingResponseDto createAssignedBookingWithLock(UsersDetails usersDetails, BookingRequestDto requestDto) {
+    private BookingResponseDto createAssignedBookingWithLock(
+            UsersDetails usersDetails, BookingRequestDto requestDto) {
         Long seatId = requestDto.getSeatId();
 
         // 락 Key 생성 (유니크)
@@ -65,5 +70,4 @@ public class BookingFacade {
             }
         }
     }
-
 }

--- a/src/main/java/com/DBP/ticketing_backend/domain/booking/service/BookingService.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/booking/service/BookingService.java
@@ -44,20 +44,20 @@ public class BookingService {
 
     @Transactional
     public BookingResponseDto createBooking(
-        UsersDetails usersDetails, BookingRequestDto bookingRequestDto) {
+            UsersDetails usersDetails, BookingRequestDto bookingRequestDto) {
 
         // 유저 조회
         Users user =
-            usersRepository
-                .findById(usersDetails.getUserId())
-                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+                usersRepository
+                        .findById(usersDetails.getUserId())
+                        .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
         // 이벤트 조회
         Long eventId = bookingRequestDto.getEventId();
         Event event =
-            eventRepository
-                .findById(eventId)
-                .orElseThrow(() -> new CustomException(ErrorCode.EVENT_NOT_FOUND));
+                eventRepository
+                        .findById(eventId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.EVENT_NOT_FOUND));
 
         // 예매 가능 시간 및 상태 확인
         validateTicketingTime(event);
@@ -74,10 +74,10 @@ public class BookingService {
             }
 
             seat =
-                seatRepository
-                    .findById(bookingRequestDto.getSeatId())
-                    // .findByIdWithLock(bookingRequestDto.getSeatId())
-                    .orElseThrow(() -> new CustomException(ErrorCode.SEAT_NOT_FOUND));
+                    seatRepository
+                            .findById(bookingRequestDto.getSeatId())
+                            // .findByIdWithLock(bookingRequestDto.getSeatId())
+                            .orElseThrow(() -> new CustomException(ErrorCode.SEAT_NOT_FOUND));
 
             // 요청한 좌석의 이벤트와 일치하는지 확인
             if (!seat.getEvent().getEventId().equals(eventId)) {
@@ -86,9 +86,9 @@ public class BookingService {
             // 자유석, 스탠딩석의 경우
         } else {
             seat =
-                seatRepository
-                    .findFirstByEvent_EventIdAndStatus(eventId, SeatStatus.AVAILABLE)
-                    .orElseThrow(() -> new CustomException(ErrorCode.SOLD_OUT));
+                    seatRepository
+                            .findFirstByEvent_EventIdAndStatus(eventId, SeatStatus.AVAILABLE)
+                            .orElseThrow(() -> new CustomException(ErrorCode.SOLD_OUT));
         }
 
         // 좌석 상태 확인 및 업데이트
@@ -99,11 +99,11 @@ public class BookingService {
 
         // 예약 생성
         Booking booking =
-            Booking.builder()
-                .users(user)
-                .status(BookingStatus.PENDING) // 초기 상태: 결제 대기
-                .totalPrice(seat.getPrice())
-                .build();
+                Booking.builder()
+                        .users(user)
+                        .status(BookingStatus.PENDING) // 초기 상태: 결제 대기
+                        .totalPrice(seat.getPrice())
+                        .build();
         Booking savedBooking = bookingRepository.save(booking);
 
         // 예약된 좌석 정보 생성
@@ -112,12 +112,12 @@ public class BookingService {
 
         // 예약된 좌석 이력 생성
         BookedSeatHistory history =
-            BookedSeatHistory.builder()
-                .bookedSeat(savedBookedSeat)
-                .booking(savedBooking)
-                .previousStatus(null) // 최초 생성이므로 이전 상태 없음
-                .currentStatus(BookingStatus.PENDING)
-                .build();
+                BookedSeatHistory.builder()
+                        .bookedSeat(savedBookedSeat)
+                        .booking(savedBooking)
+                        .previousStatus(null) // 최초 생성이므로 이전 상태 없음
+                        .currentStatus(BookingStatus.PENDING)
+                        .build();
 
         bookedSeatHistoryRepository.save(history);
 
@@ -128,9 +128,9 @@ public class BookingService {
     public BookingResponseDto cancelBooking(UsersDetails usersDetails, Long bookingId) {
 
         Booking booking =
-            bookingRepository
-                .findById(bookingId)
-                .orElseThrow(() -> new CustomException(ErrorCode.BOOKING_NOT_FOUND));
+                bookingRepository
+                        .findById(bookingId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.BOOKING_NOT_FOUND));
 
         // 예약한 유저와 요청한 유저가 같은지 확인
         if (!booking.getUsers().getUserId().equals(usersDetails.getUserId())) {
@@ -138,9 +138,9 @@ public class BookingService {
         }
 
         BookedSeat bookedSeat =
-            bookedSeatRepository
-                .findByBooking(booking)
-                .orElseThrow(() -> new CustomException(ErrorCode.SEAT_NOT_FOUND));
+                bookedSeatRepository
+                        .findByBooking(booking)
+                        .orElseThrow(() -> new CustomException(ErrorCode.SEAT_NOT_FOUND));
 
         // 상태에 따른 분기 처리
         if (booking.getStatus() == BookingStatus.PENDING) {
@@ -172,7 +172,7 @@ public class BookingService {
     }
 
     private void changeBookingStatusWithHistory(
-        Booking booking, BookedSeat bookedSeat, BookingStatus newStatus) {
+            Booking booking, BookedSeat bookedSeat, BookingStatus newStatus) {
         // 1. 이전 상태 기록
         BookingStatus previousStatus = booking.getStatus();
 
@@ -181,12 +181,12 @@ public class BookingService {
 
         // 3. 히스토리 저장
         BookedSeatHistory history =
-            BookedSeatHistory.builder()
-                .bookedSeat(bookedSeat)
-                .booking(booking)
-                .previousStatus(previousStatus) // 변경 전 상태 (예: CONFIRMED)
-                .currentStatus(newStatus) // 변경 후 상태 (예: CANCELLED)
-                .build();
+                BookedSeatHistory.builder()
+                        .bookedSeat(bookedSeat)
+                        .booking(booking)
+                        .previousStatus(previousStatus) // 변경 전 상태 (예: CONFIRMED)
+                        .currentStatus(newStatus) // 변경 후 상태 (예: CANCELLED)
+                        .build();
 
         bookedSeatHistoryRepository.save(history);
     }
@@ -196,9 +196,9 @@ public class BookingService {
 
         // 예약 조회
         Booking booking =
-            bookingRepository
-                .findById(bookingId)
-                .orElseThrow(() -> new CustomException(ErrorCode.BOOKING_NOT_FOUND));
+                bookingRepository
+                        .findById(bookingId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.BOOKING_NOT_FOUND));
 
         // 예약한 유저와 요청한 유저가 같은지 확인
         if (!booking.getUsers().getUserId().equals(usersDetails.getUserId())) {
@@ -212,9 +212,9 @@ public class BookingService {
 
         // 예약된 좌석 조회
         BookedSeat bookedSeat =
-            bookedSeatRepository
-                .findByBooking(booking)
-                .orElseThrow(() -> new CustomException(ErrorCode.SEAT_NOT_FOUND));
+                bookedSeatRepository
+                        .findByBooking(booking)
+                        .orElseThrow(() -> new CustomException(ErrorCode.SEAT_NOT_FOUND));
 
         Seat seat = bookedSeat.getSeat();
 
@@ -246,9 +246,9 @@ public class BookingService {
     public List<BookingResponseDto> getMyBookings(UsersDetails usersDetails, BookingStatus status) {
 
         Users user =
-            usersRepository
-                .findById(usersDetails.getUserId())
-                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+                usersRepository
+                        .findById(usersDetails.getUserId())
+                        .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
         List<Booking> bookings;
 
@@ -260,20 +260,20 @@ public class BookingService {
 
         // Entity -> DTO 변환
         return bookings.stream()
-            .map(
-                booking -> {
-                    // BookedSeat를 통해 Seat 정보 가져오기
-                    BookedSeat bookedSeat =
-                        bookedSeatRepository
-                            .findByBooking(booking)
-                            .orElseThrow(
-                                () ->
-                                    new CustomException(
-                                        ErrorCode.SEAT_NOT_FOUND));
+                .map(
+                        booking -> {
+                            // BookedSeat를 통해 Seat 정보 가져오기
+                            BookedSeat bookedSeat =
+                                    bookedSeatRepository
+                                            .findByBooking(booking)
+                                            .orElseThrow(
+                                                    () ->
+                                                            new CustomException(
+                                                                    ErrorCode.SEAT_NOT_FOUND));
 
-                    return BookingResponseDto.from(booking, bookedSeat.getSeat());
-                })
-            .collect(Collectors.toList());
+                            return BookingResponseDto.from(booking, bookedSeat.getSeat());
+                        })
+                .collect(Collectors.toList());
     }
 
     @Transactional
@@ -283,15 +283,15 @@ public class BookingService {
 
         // 만료된 예약들 조회 (PENDING 상태 & 5분 지남)
         List<Booking> expiredBookings =
-            bookingRepository.findByStatusAndCreatedAtBefore(
-                BookingStatus.PENDING, fiveMinutesAgo);
+                bookingRepository.findByStatusAndCreatedAtBefore(
+                        BookingStatus.PENDING, fiveMinutesAgo);
 
         // 하나씩 취소 처리
         for (Booking booking : expiredBookings) {
             BookedSeat bookedSeat =
-                bookedSeatRepository
-                    .findByBooking(booking)
-                    .orElseThrow(() -> new CustomException(ErrorCode.SEAT_NOT_FOUND));
+                    bookedSeatRepository
+                            .findByBooking(booking)
+                            .orElseThrow(() -> new CustomException(ErrorCode.SEAT_NOT_FOUND));
             cancelPendingBooking(booking, bookedSeat);
         }
     }

--- a/src/main/java/com/DBP/ticketing_backend/domain/booking/service/BookingService.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/booking/service/BookingService.java
@@ -44,20 +44,20 @@ public class BookingService {
 
     @Transactional
     public BookingResponseDto createBooking(
-            UsersDetails usersDetails, BookingRequestDto bookingRequestDto) {
+        UsersDetails usersDetails, BookingRequestDto bookingRequestDto) {
 
         // 유저 조회
         Users user =
-                usersRepository
-                        .findById(usersDetails.getUserId())
-                        .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+            usersRepository
+                .findById(usersDetails.getUserId())
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
         // 이벤트 조회
         Long eventId = bookingRequestDto.getEventId();
         Event event =
-                eventRepository
-                        .findById(eventId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.EVENT_NOT_FOUND));
+            eventRepository
+                .findById(eventId)
+                .orElseThrow(() -> new CustomException(ErrorCode.EVENT_NOT_FOUND));
 
         // 예매 가능 시간 및 상태 확인
         validateTicketingTime(event);
@@ -74,9 +74,10 @@ public class BookingService {
             }
 
             seat =
-                    seatRepository
-                            .findByIdWithLock(bookingRequestDto.getSeatId())
-                            .orElseThrow(() -> new CustomException(ErrorCode.SEAT_NOT_FOUND));
+                seatRepository
+                    .findById(bookingRequestDto.getSeatId())
+                    // .findByIdWithLock(bookingRequestDto.getSeatId())
+                    .orElseThrow(() -> new CustomException(ErrorCode.SEAT_NOT_FOUND));
 
             // 요청한 좌석의 이벤트와 일치하는지 확인
             if (!seat.getEvent().getEventId().equals(eventId)) {
@@ -85,9 +86,9 @@ public class BookingService {
             // 자유석, 스탠딩석의 경우
         } else {
             seat =
-                    seatRepository
-                            .findFirstByEvent_EventIdAndStatus(eventId, SeatStatus.AVAILABLE)
-                            .orElseThrow(() -> new CustomException(ErrorCode.SOLD_OUT));
+                seatRepository
+                    .findFirstByEvent_EventIdAndStatus(eventId, SeatStatus.AVAILABLE)
+                    .orElseThrow(() -> new CustomException(ErrorCode.SOLD_OUT));
         }
 
         // 좌석 상태 확인 및 업데이트
@@ -98,11 +99,11 @@ public class BookingService {
 
         // 예약 생성
         Booking booking =
-                Booking.builder()
-                        .users(user)
-                        .status(BookingStatus.PENDING) // 초기 상태: 결제 대기
-                        .totalPrice(seat.getPrice())
-                        .build();
+            Booking.builder()
+                .users(user)
+                .status(BookingStatus.PENDING) // 초기 상태: 결제 대기
+                .totalPrice(seat.getPrice())
+                .build();
         Booking savedBooking = bookingRepository.save(booking);
 
         // 예약된 좌석 정보 생성
@@ -111,12 +112,12 @@ public class BookingService {
 
         // 예약된 좌석 이력 생성
         BookedSeatHistory history =
-                BookedSeatHistory.builder()
-                        .bookedSeat(savedBookedSeat)
-                        .booking(savedBooking)
-                        .previousStatus(null) // 최초 생성이므로 이전 상태 없음
-                        .currentStatus(BookingStatus.PENDING)
-                        .build();
+            BookedSeatHistory.builder()
+                .bookedSeat(savedBookedSeat)
+                .booking(savedBooking)
+                .previousStatus(null) // 최초 생성이므로 이전 상태 없음
+                .currentStatus(BookingStatus.PENDING)
+                .build();
 
         bookedSeatHistoryRepository.save(history);
 
@@ -127,9 +128,9 @@ public class BookingService {
     public BookingResponseDto cancelBooking(UsersDetails usersDetails, Long bookingId) {
 
         Booking booking =
-                bookingRepository
-                        .findById(bookingId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.BOOKING_NOT_FOUND));
+            bookingRepository
+                .findById(bookingId)
+                .orElseThrow(() -> new CustomException(ErrorCode.BOOKING_NOT_FOUND));
 
         // 예약한 유저와 요청한 유저가 같은지 확인
         if (!booking.getUsers().getUserId().equals(usersDetails.getUserId())) {
@@ -137,9 +138,9 @@ public class BookingService {
         }
 
         BookedSeat bookedSeat =
-                bookedSeatRepository
-                        .findByBooking(booking)
-                        .orElseThrow(() -> new CustomException(ErrorCode.SEAT_NOT_FOUND));
+            bookedSeatRepository
+                .findByBooking(booking)
+                .orElseThrow(() -> new CustomException(ErrorCode.SEAT_NOT_FOUND));
 
         // 상태에 따른 분기 처리
         if (booking.getStatus() == BookingStatus.PENDING) {
@@ -171,7 +172,7 @@ public class BookingService {
     }
 
     private void changeBookingStatusWithHistory(
-            Booking booking, BookedSeat bookedSeat, BookingStatus newStatus) {
+        Booking booking, BookedSeat bookedSeat, BookingStatus newStatus) {
         // 1. 이전 상태 기록
         BookingStatus previousStatus = booking.getStatus();
 
@@ -180,12 +181,12 @@ public class BookingService {
 
         // 3. 히스토리 저장
         BookedSeatHistory history =
-                BookedSeatHistory.builder()
-                        .bookedSeat(bookedSeat)
-                        .booking(booking)
-                        .previousStatus(previousStatus) // 변경 전 상태 (예: CONFIRMED)
-                        .currentStatus(newStatus) // 변경 후 상태 (예: CANCELLED)
-                        .build();
+            BookedSeatHistory.builder()
+                .bookedSeat(bookedSeat)
+                .booking(booking)
+                .previousStatus(previousStatus) // 변경 전 상태 (예: CONFIRMED)
+                .currentStatus(newStatus) // 변경 후 상태 (예: CANCELLED)
+                .build();
 
         bookedSeatHistoryRepository.save(history);
     }
@@ -195,9 +196,9 @@ public class BookingService {
 
         // 예약 조회
         Booking booking =
-                bookingRepository
-                        .findById(bookingId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.BOOKING_NOT_FOUND));
+            bookingRepository
+                .findById(bookingId)
+                .orElseThrow(() -> new CustomException(ErrorCode.BOOKING_NOT_FOUND));
 
         // 예약한 유저와 요청한 유저가 같은지 확인
         if (!booking.getUsers().getUserId().equals(usersDetails.getUserId())) {
@@ -211,9 +212,9 @@ public class BookingService {
 
         // 예약된 좌석 조회
         BookedSeat bookedSeat =
-                bookedSeatRepository
-                        .findByBooking(booking)
-                        .orElseThrow(() -> new CustomException(ErrorCode.SEAT_NOT_FOUND));
+            bookedSeatRepository
+                .findByBooking(booking)
+                .orElseThrow(() -> new CustomException(ErrorCode.SEAT_NOT_FOUND));
 
         Seat seat = bookedSeat.getSeat();
 
@@ -245,9 +246,9 @@ public class BookingService {
     public List<BookingResponseDto> getMyBookings(UsersDetails usersDetails, BookingStatus status) {
 
         Users user =
-                usersRepository
-                        .findById(usersDetails.getUserId())
-                        .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+            usersRepository
+                .findById(usersDetails.getUserId())
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
         List<Booking> bookings;
 
@@ -259,20 +260,20 @@ public class BookingService {
 
         // Entity -> DTO 변환
         return bookings.stream()
-                .map(
-                        booking -> {
-                            // BookedSeat를 통해 Seat 정보 가져오기
-                            BookedSeat bookedSeat =
-                                    bookedSeatRepository
-                                            .findByBooking(booking)
-                                            .orElseThrow(
-                                                    () ->
-                                                            new CustomException(
-                                                                    ErrorCode.SEAT_NOT_FOUND));
+            .map(
+                booking -> {
+                    // BookedSeat를 통해 Seat 정보 가져오기
+                    BookedSeat bookedSeat =
+                        bookedSeatRepository
+                            .findByBooking(booking)
+                            .orElseThrow(
+                                () ->
+                                    new CustomException(
+                                        ErrorCode.SEAT_NOT_FOUND));
 
-                            return BookingResponseDto.from(booking, bookedSeat.getSeat());
-                        })
-                .collect(Collectors.toList());
+                    return BookingResponseDto.from(booking, bookedSeat.getSeat());
+                })
+            .collect(Collectors.toList());
     }
 
     @Transactional
@@ -282,15 +283,15 @@ public class BookingService {
 
         // 만료된 예약들 조회 (PENDING 상태 & 5분 지남)
         List<Booking> expiredBookings =
-                bookingRepository.findByStatusAndCreatedAtBefore(
-                        BookingStatus.PENDING, fiveMinutesAgo);
+            bookingRepository.findByStatusAndCreatedAtBefore(
+                BookingStatus.PENDING, fiveMinutesAgo);
 
         // 하나씩 취소 처리
         for (Booking booking : expiredBookings) {
             BookedSeat bookedSeat =
-                    bookedSeatRepository
-                            .findByBooking(booking)
-                            .orElseThrow(() -> new CustomException(ErrorCode.SEAT_NOT_FOUND));
+                bookedSeatRepository
+                    .findByBooking(booking)
+                    .orElseThrow(() -> new CustomException(ErrorCode.SEAT_NOT_FOUND));
             cancelPendingBooking(booking, bookedSeat);
         }
     }

--- a/src/main/java/com/DBP/ticketing_backend/domain/seat/repository/SeatRepository.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/seat/repository/SeatRepository.java
@@ -20,9 +20,9 @@ public interface SeatRepository extends JpaRepository<Seat, Long> {
                     + " s.template.row, s.template.column")
     List<Seat> findAllByEventId(@Param("eventId") Long eventId);
 
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("select s from Seat s where s.seatId = :seatId")
-    Optional<Seat> findByIdWithLock(Long seatId);
+//    @Lock(LockModeType.PESSIMISTIC_WRITE)
+//    @Query("select s from Seat s where s.seatId = :seatId")
+//    Optional<Seat> findByIdWithLock(Long seatId);
 
     Optional<Seat> findFirstByEvent_EventIdAndStatus(Long eventId, SeatStatus seatStatus);
 }

--- a/src/main/java/com/DBP/ticketing_backend/domain/seat/repository/SeatRepository.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/seat/repository/SeatRepository.java
@@ -3,10 +3,7 @@ package com.DBP.ticketing_backend.domain.seat.repository;
 import com.DBP.ticketing_backend.domain.seat.entity.Seat;
 import com.DBP.ticketing_backend.domain.seat.enums.SeatStatus;
 
-import jakarta.persistence.LockModeType;
-
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -20,9 +17,9 @@ public interface SeatRepository extends JpaRepository<Seat, Long> {
                     + " s.template.row, s.template.column")
     List<Seat> findAllByEventId(@Param("eventId") Long eventId);
 
-//    @Lock(LockModeType.PESSIMISTIC_WRITE)
-//    @Query("select s from Seat s where s.seatId = :seatId")
-//    Optional<Seat> findByIdWithLock(Long seatId);
+    //    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    //    @Query("select s from Seat s where s.seatId = :seatId")
+    //    Optional<Seat> findByIdWithLock(Long seatId);
 
     Optional<Seat> findFirstByEvent_EventIdAndStatus(Long eventId, SeatStatus seatStatus);
 }

--- a/src/main/java/com/DBP/ticketing_backend/domain/users/entity/Users.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/users/entity/Users.java
@@ -23,6 +23,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@Builder
 public class Users extends BaseEntity {
 
     @Id

--- a/src/test/java/com/DBP/ticketing_backend/BookingConcurrencyTest.java
+++ b/src/test/java/com/DBP/ticketing_backend/BookingConcurrencyTest.java
@@ -1,0 +1,138 @@
+package com.DBP.ticketing_backend;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.DBP.ticketing_backend.domain.auth.dto.UsersDetails;
+import com.DBP.ticketing_backend.domain.bookedseat.entity.BookedSeat;
+import com.DBP.ticketing_backend.domain.bookedseat.repository.BookedSeatRepository;
+import com.DBP.ticketing_backend.domain.bookedseathistory.entity.BookedSeatHistory;
+import com.DBP.ticketing_backend.domain.bookedseathistory.repository.BookedSeatHistoryRepository;
+import com.DBP.ticketing_backend.domain.booking.dto.BookingRequestDto;
+import com.DBP.ticketing_backend.domain.booking.entity.Booking;
+import com.DBP.ticketing_backend.domain.booking.facade.BookingFacade;
+import com.DBP.ticketing_backend.domain.booking.repository.BookingRepository;
+import com.DBP.ticketing_backend.domain.seat.entity.Seat;
+import com.DBP.ticketing_backend.domain.seat.enums.SeatStatus;
+import com.DBP.ticketing_backend.domain.seat.repository.SeatRepository;
+import com.DBP.ticketing_backend.domain.users.entity.Users;
+import com.DBP.ticketing_backend.domain.users.enums.UsersRole;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest
+@TestPropertySource(
+    properties = {
+        "jwt.secret=dGhpcyBpcyBhIHZlcnkgbG9uZyBzZWNyZXQga2V5IGZvciBqd3QgdGVzdGluZw==",
+        "jwt.access-token-expiration=3600000",
+        "jwt.refresh-token-expiration=86400000"
+    })
+public class BookingConcurrencyTest {
+
+    @Autowired
+    private BookingFacade bookingFacade;
+    @Autowired
+    private BookedSeatRepository bookedSeatRepository;
+    @Autowired
+    private BookingRepository bookingRepository;
+    @Autowired
+    private BookedSeatHistoryRepository bookedSeatHistoryRepository;
+    @Autowired
+    private SeatRepository seatRepository;
+
+
+    @Test
+    void 지정석_동시예매_100명_테스트() throws InterruptedException {
+        // given
+
+        UsersDetails mockUser = new UsersDetails(
+            Users.builder()
+                .userId(3L)
+                .role(UsersRole.ROLE_USER)
+                .build()
+        );
+
+        int threadCount = 100; // 100명이 동시에
+        ExecutorService executorService = Executors.newFixedThreadPool(32);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        // 성공 횟수, 실패 횟수 카운터
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger failCount = new AtomicInteger();
+
+        // 테스트용 요청 DTO
+        BookingRequestDto request = BookingRequestDto.builder()
+            .eventId(3L) // 9999년에 진행되는 이벤트
+            .seatId(2001L)
+            .build();
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    bookingFacade.createBooking(mockUser, request);
+                    successCount.getAndIncrement(); // 성공하면 +1
+                } catch (Exception e) {
+                    failCount.getAndIncrement(); // 실패(이미 예약됨)하면 +1
+                    System.out.println("예매 실패: " + e.getMessage());
+                } finally {
+                    latch.countDown(); // 스레드 하나 끝남
+                }
+            });
+        }
+
+        latch.await(); // 100명이 다 끝날 때까지 대기
+
+        // then
+        System.out.println("성공 횟수: " + successCount.get());
+        System.out.println("실패 횟수: " + failCount.get());
+
+        // 검증: 오직 1명만 성공해야 함
+        assertEquals(1, successCount.get());
+        // 검증: 99명은 실패해야 함
+        assertEquals(99, failCount.get());
+    }
+
+    @AfterEach
+    void tearDown() {
+        // 1. 테스트에 사용한 좌석 ID
+        Long targetSeatId = 2001L;
+
+        // 2. 해당 좌석을 조회
+        Seat seat = seatRepository.findById(targetSeatId).orElseThrow();
+
+        // 3. 좌석 상태를 'AVAILABLE'로 원상복구
+        seat.updateStatus(SeatStatus.AVAILABLE);
+        seatRepository.save(seat);
+
+        // 4. 테스트로 인해 생긴 예매 내역 삭제
+        List<BookedSeat> bookedSeats = bookedSeatRepository.findAll().stream()
+            .filter(bs -> bs.getSeat().getSeatId().equals(targetSeatId))
+            .toList();
+
+        for (BookedSeat bs : bookedSeats) {
+            // History 삭제
+            List<BookedSeatHistory> histories = bookedSeatHistoryRepository.findAll().stream()
+                .filter(h -> h.getBookedSeat().getBookedSeatId().equals(bs.getBookedSeatId()))
+                .toList();
+            bookedSeatHistoryRepository.deleteAll(histories);
+
+            // Booking 찾기
+            Booking booking = bs.getBooking();
+
+            // BookedSeat 삭제
+            bookedSeatRepository.delete(bs);
+
+            // Booking 삭제
+            bookingRepository.delete(booking);
+        }
+    }
+
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,9 +1,9 @@
 spring:
   datasource:
-    url: jdbc:h2:mem:testdb
-    driver-class-name: org.h2.Driver
-    username: sa
-    password:
+    url: jdbc:mysql://localhost:3306/mol?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: root
+    password: jamespark1380@
 
   data:
     redis:
@@ -12,4 +12,4 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #17 

## 📝작업 내용
- 기존 MySQL에서 하던 Seat에 대한 비관락 삭제
- Redisson을 사용하기 위한 BookFacade 클래스 작성
- 지정석의 경우 BookFacade를 거쳐 분산락 수행
- 스탠딩/자율석의 경우 BookService를 호출
- testCode를 로컬 DB와 연결하여 100명의 지정석 동시성 수행

## 📸 스크린샷 (선택)
<img width="1875" height="455" alt="image" src="https://github.com/user-attachments/assets/6c93ad4b-6348-4ae1-b9cf-3b3d730d3f99" />
<img width="2022" height="1051" alt="image" src="https://github.com/user-attachments/assets/d69a1cce-80bd-49d1-bc20-8131ac1c227b" />


## 🧪 테스트 여부
- [x] 테스트 코드를 작성함
- [x] 테스트를 수행함

## 💬리뷰 요구사항(선택)
- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?