### PR TITLE
feat(19): 대기열 큐 구현

### DIFF
--- a/src/main/java/com/DBP/ticketing_backend/domain/booking/controller/BookingController.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/booking/controller/BookingController.java
@@ -8,6 +8,8 @@ import com.DBP.ticketing_backend.domain.booking.facade.BookingFacade;
 import com.DBP.ticketing_backend.domain.booking.service.BookingService;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 import lombok.RequiredArgsConstructor;
@@ -34,15 +36,48 @@ public class BookingController {
     private final BookingService bookingService;
     private final BookingFacade bookingFacade;
 
-    @Operation(summary = "예매 생성", description = "이벤트 혹은 좌석 정보로 이벤트를 예매합니다.")
-    @PostMapping
+    @Operation(
+        summary = "예매 생성",
+        description =
+            """
+            이벤트 혹은 좌석 정보를 기반으로 예매를 생성합니다.
+
+            **권한:**
+            - 인증된 사용자만 접근 가능
+
+            **참고:**
+            - 요청 본문에 예매 정보를 포함해야 합니다.
+            """
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "예매 생성 성공"),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터"),
+        @ApiResponse(responseCode = "401", description = "인증되지 않은 요청")
+    })    @PostMapping
     public ResponseEntity<BookingResponseDto> createBooking(
             @AuthenticationPrincipal UsersDetails usersDetails,
             @RequestBody BookingRequestDto bookingRequestDto) {
         return ResponseEntity.ok(bookingFacade.createBooking(usersDetails, bookingRequestDto));
     }
 
-    @Operation(summary = "예매 취소", description = "결제 대기 혹은 예매 완료된 예매를 취소합니다.")
+    @Operation(
+        summary = "예매 취소",
+        description =
+            """
+            결제 대기 상태 또는 예매 완료된 예매를 취소합니다.
+
+            **권한:**
+            - 인증된 사용자만 접근 가능
+
+            **참고:**
+            - 예매 ID를 경로 변수로 전달해야 합니다.
+            """
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "예매 취소 성공"),
+        @ApiResponse(responseCode = "401", description = "인증되지 않은 요청"),
+        @ApiResponse(responseCode = "404", description = "예매를 찾을 수 없음")
+    })
     @DeleteMapping("/{bookingId}")
     public ResponseEntity<BookingResponseDto> cancelBooking(
             @AuthenticationPrincipal UsersDetails usersDetails,
@@ -50,7 +85,24 @@ public class BookingController {
         return ResponseEntity.ok(bookingService.cancelBooking(usersDetails, bookingId));
     }
 
-    @Operation(summary = "결제", description = "결제를 통해 예매를 확정합니다.")
+    @Operation(
+        summary = "결제",
+        description =
+            """
+            예매를 결제하여 확정합니다.
+
+            **권한:**
+            - 인증된 사용자만 접근 가능
+
+            **참고:**
+            - 예매 ID를 경로 변수로 전달해야 합니다.
+            """
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "결제 성공"),
+        @ApiResponse(responseCode = "401", description = "인증되지 않은 요청"),
+        @ApiResponse(responseCode = "404", description = "예매를 찾을 수 없음")
+    })
     @PostMapping("/{bookingId}")
     public ResponseEntity<BookingResponseDto> payBooking(
             @AuthenticationPrincipal UsersDetails usersDetails,
@@ -58,10 +110,24 @@ public class BookingController {
         return ResponseEntity.ok(bookingService.payBooking(usersDetails, bookingId));
     }
 
-    @GetMapping("/my")
     @Operation(
-            summary = "내 예매 내역 조회",
-            description = "로그인한 유저의 예매 내역을 조회합니다. status 파라미터로 필터링 가능합니다.")
+        summary = "내 예매 내역 조회",
+        description =
+            """
+            로그인한 사용자의 예매 내역을 조회합니다.
+
+            **권한:**
+            - 인증된 사용자만 접근 가능
+
+            **참고:**
+            - `status` 파라미터를 사용하여 예매 상태별로 필터링할 수 있습니다.
+            """
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "조회 성공"),
+        @ApiResponse(responseCode = "401", description = "인증되지 않은 요청")
+    })
+    @GetMapping("/my")
     public ResponseEntity<List<BookingResponseDto>> getMyBookings(
             @AuthenticationPrincipal UsersDetails usersDetails,
             @RequestParam(required = false) BookingStatus status // ?status=CONFIRMED

--- a/src/main/java/com/DBP/ticketing_backend/domain/booking/controller/BookingController.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/booking/controller/BookingController.java
@@ -37,9 +37,9 @@ public class BookingController {
     private final BookingFacade bookingFacade;
 
     @Operation(
-        summary = "예매 생성",
-        description =
-            """
+            summary = "예매 생성",
+            description =
+                    """
             이벤트 혹은 좌석 정보를 기반으로 예매를 생성합니다.
 
             **권한:**
@@ -47,13 +47,13 @@ public class BookingController {
 
             **참고:**
             - 요청 본문에 예매 정보를 포함해야 합니다.
-            """
-    )
+            """)
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "예매 생성 성공"),
         @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터"),
         @ApiResponse(responseCode = "401", description = "인증되지 않은 요청")
-    })    @PostMapping
+    })
+    @PostMapping
     public ResponseEntity<BookingResponseDto> createBooking(
             @AuthenticationPrincipal UsersDetails usersDetails,
             @RequestBody BookingRequestDto bookingRequestDto) {
@@ -61,9 +61,9 @@ public class BookingController {
     }
 
     @Operation(
-        summary = "예매 취소",
-        description =
-            """
+            summary = "예매 취소",
+            description =
+                    """
             결제 대기 상태 또는 예매 완료된 예매를 취소합니다.
 
             **권한:**
@@ -71,8 +71,7 @@ public class BookingController {
 
             **참고:**
             - 예매 ID를 경로 변수로 전달해야 합니다.
-            """
-    )
+            """)
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "예매 취소 성공"),
         @ApiResponse(responseCode = "401", description = "인증되지 않은 요청"),
@@ -86,9 +85,9 @@ public class BookingController {
     }
 
     @Operation(
-        summary = "결제",
-        description =
-            """
+            summary = "결제",
+            description =
+                    """
             예매를 결제하여 확정합니다.
 
             **권한:**
@@ -96,8 +95,7 @@ public class BookingController {
 
             **참고:**
             - 예매 ID를 경로 변수로 전달해야 합니다.
-            """
-    )
+            """)
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "결제 성공"),
         @ApiResponse(responseCode = "401", description = "인증되지 않은 요청"),
@@ -111,9 +109,9 @@ public class BookingController {
     }
 
     @Operation(
-        summary = "내 예매 내역 조회",
-        description =
-            """
+            summary = "내 예매 내역 조회",
+            description =
+                    """
             로그인한 사용자의 예매 내역을 조회합니다.
 
             **권한:**
@@ -121,8 +119,7 @@ public class BookingController {
 
             **참고:**
             - `status` 파라미터를 사용하여 예매 상태별로 필터링할 수 있습니다.
-            """
-    )
+            """)
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "조회 성공"),
         @ApiResponse(responseCode = "401", description = "인증되지 않은 요청")

--- a/src/main/java/com/DBP/ticketing_backend/domain/booking/controller/BookingController.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/booking/controller/BookingController.java
@@ -26,7 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/booking")
+@RequestMapping("/api/bookings")
 @RequiredArgsConstructor
 @Tag(name = " 예매 api", description = "예매와 관련된 API 입니다.")
 public class BookingController {

--- a/src/main/java/com/DBP/ticketing_backend/domain/booking/service/BookingService.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/booking/service/BookingService.java
@@ -46,20 +46,20 @@ public class BookingService {
 
     @Transactional
     public BookingResponseDto createBooking(
-        UsersDetails usersDetails, BookingRequestDto bookingRequestDto) {
+            UsersDetails usersDetails, BookingRequestDto bookingRequestDto) {
 
         // 유저 조회
         Users user =
-            usersRepository
-                .findById(usersDetails.getUserId())
-                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+                usersRepository
+                        .findById(usersDetails.getUserId())
+                        .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
         // 이벤트 조회
         Long eventId = bookingRequestDto.getEventId();
         Event event =
-            eventRepository
-                .findById(eventId)
-                .orElseThrow(() -> new CustomException(ErrorCode.EVENT_NOT_FOUND));
+                eventRepository
+                        .findById(eventId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.EVENT_NOT_FOUND));
 
         // 예매 가능 시간 및 상태 확인
         validateTicketingTime(event);
@@ -76,10 +76,10 @@ public class BookingService {
             }
 
             seat =
-                seatRepository
-                    .findById(bookingRequestDto.getSeatId())
-                    // .findByIdWithLock(bookingRequestDto.getSeatId())
-                    .orElseThrow(() -> new CustomException(ErrorCode.SEAT_NOT_FOUND));
+                    seatRepository
+                            .findById(bookingRequestDto.getSeatId())
+                            // .findByIdWithLock(bookingRequestDto.getSeatId())
+                            .orElseThrow(() -> new CustomException(ErrorCode.SEAT_NOT_FOUND));
 
             // 요청한 좌석의 이벤트와 일치하는지 확인
             if (!seat.getEvent().getEventId().equals(eventId)) {
@@ -88,10 +88,10 @@ public class BookingService {
             // 자유석, 스탠딩석의 경우
         } else {
             seat =
-                seatRepository
-                    .findFirstByEvent_EventIdAndStatusOrderBySeatIdAscWithLock(eventId,
-                        SeatStatus.AVAILABLE)
-                    .orElseThrow(() -> new CustomException(ErrorCode.SOLD_OUT));
+                    seatRepository
+                            .findFirstByEvent_EventIdAndStatusOrderBySeatIdAscWithLock(
+                                    eventId, SeatStatus.AVAILABLE)
+                            .orElseThrow(() -> new CustomException(ErrorCode.SOLD_OUT));
         }
 
         // 좌석 상태 확인 및 업데이트
@@ -102,11 +102,11 @@ public class BookingService {
 
         // 예약 생성
         Booking booking =
-            Booking.builder()
-                .users(user)
-                .status(BookingStatus.PENDING) // 초기 상태: 결제 대기
-                .totalPrice(seat.getPrice())
-                .build();
+                Booking.builder()
+                        .users(user)
+                        .status(BookingStatus.PENDING) // 초기 상태: 결제 대기
+                        .totalPrice(seat.getPrice())
+                        .build();
         Booking savedBooking = bookingRepository.save(booking);
 
         // 예약된 좌석 정보 생성
@@ -115,12 +115,12 @@ public class BookingService {
 
         // 예약된 좌석 이력 생성
         BookedSeatHistory history =
-            BookedSeatHistory.builder()
-                .bookedSeat(savedBookedSeat)
-                .booking(savedBooking)
-                .previousStatus(null) // 최초 생성이므로 이전 상태 없음
-                .currentStatus(BookingStatus.PENDING)
-                .build();
+                BookedSeatHistory.builder()
+                        .bookedSeat(savedBookedSeat)
+                        .booking(savedBooking)
+                        .previousStatus(null) // 최초 생성이므로 이전 상태 없음
+                        .currentStatus(BookingStatus.PENDING)
+                        .build();
 
         bookedSeatHistoryRepository.save(history);
 
@@ -131,9 +131,9 @@ public class BookingService {
     public BookingResponseDto cancelBooking(UsersDetails usersDetails, Long bookingId) {
 
         Booking booking =
-            bookingRepository
-                .findById(bookingId)
-                .orElseThrow(() -> new CustomException(ErrorCode.BOOKING_NOT_FOUND));
+                bookingRepository
+                        .findById(bookingId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.BOOKING_NOT_FOUND));
 
         // 예약한 유저와 요청한 유저가 같은지 확인
         if (!booking.getUsers().getUserId().equals(usersDetails.getUserId())) {
@@ -141,9 +141,9 @@ public class BookingService {
         }
 
         BookedSeat bookedSeat =
-            bookedSeatRepository
-                .findByBooking(booking)
-                .orElseThrow(() -> new CustomException(ErrorCode.SEAT_NOT_FOUND));
+                bookedSeatRepository
+                        .findByBooking(booking)
+                        .orElseThrow(() -> new CustomException(ErrorCode.SEAT_NOT_FOUND));
 
         // 상태에 따른 분기 처리
         if (booking.getStatus() == BookingStatus.PENDING) {
@@ -154,8 +154,8 @@ public class BookingService {
             throw new CustomException(ErrorCode.INVALID_BOOKING_STATUS);
         }
 
-        waitingQueueService.popQueue(bookedSeat.getSeat().getEvent().getEventId(),
-            usersDetails.getUserId());
+        waitingQueueService.popQueue(
+                bookedSeat.getSeat().getEvent().getEventId(), usersDetails.getUserId());
 
         return BookingResponseDto.from(booking, bookedSeat.getSeat());
     }
@@ -179,7 +179,7 @@ public class BookingService {
     }
 
     private void changeBookingStatusWithHistory(
-        Booking booking, BookedSeat bookedSeat, BookingStatus newStatus) {
+            Booking booking, BookedSeat bookedSeat, BookingStatus newStatus) {
         // 1. 이전 상태 기록
         BookingStatus previousStatus = booking.getStatus();
 
@@ -188,12 +188,12 @@ public class BookingService {
 
         // 3. 히스토리 저장
         BookedSeatHistory history =
-            BookedSeatHistory.builder()
-                .bookedSeat(bookedSeat)
-                .booking(booking)
-                .previousStatus(previousStatus) // 변경 전 상태 (예: CONFIRMED)
-                .currentStatus(newStatus) // 변경 후 상태 (예: CANCELLED)
-                .build();
+                BookedSeatHistory.builder()
+                        .bookedSeat(bookedSeat)
+                        .booking(booking)
+                        .previousStatus(previousStatus) // 변경 전 상태 (예: CONFIRMED)
+                        .currentStatus(newStatus) // 변경 후 상태 (예: CANCELLED)
+                        .build();
 
         bookedSeatHistoryRepository.save(history);
     }
@@ -203,9 +203,9 @@ public class BookingService {
 
         // 예약 조회
         Booking booking =
-            bookingRepository
-                .findById(bookingId)
-                .orElseThrow(() -> new CustomException(ErrorCode.BOOKING_NOT_FOUND));
+                bookingRepository
+                        .findById(bookingId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.BOOKING_NOT_FOUND));
 
         // 예약한 유저와 요청한 유저가 같은지 확인
         if (!booking.getUsers().getUserId().equals(usersDetails.getUserId())) {
@@ -219,9 +219,9 @@ public class BookingService {
 
         // 예약된 좌석 조회
         BookedSeat bookedSeat =
-            bookedSeatRepository
-                .findByBooking(booking)
-                .orElseThrow(() -> new CustomException(ErrorCode.SEAT_NOT_FOUND));
+                bookedSeatRepository
+                        .findByBooking(booking)
+                        .orElseThrow(() -> new CustomException(ErrorCode.SEAT_NOT_FOUND));
 
         Seat seat = bookedSeat.getSeat();
 
@@ -255,9 +255,9 @@ public class BookingService {
     public List<BookingResponseDto> getMyBookings(UsersDetails usersDetails, BookingStatus status) {
 
         Users user =
-            usersRepository
-                .findById(usersDetails.getUserId())
-                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+                usersRepository
+                        .findById(usersDetails.getUserId())
+                        .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
         List<Booking> bookings;
 
@@ -269,20 +269,20 @@ public class BookingService {
 
         // Entity -> DTO 변환
         return bookings.stream()
-            .map(
-                booking -> {
-                    // BookedSeat를 통해 Seat 정보 가져오기
-                    BookedSeat bookedSeat =
-                        bookedSeatRepository
-                            .findByBooking(booking)
-                            .orElseThrow(
-                                () ->
-                                    new CustomException(
-                                        ErrorCode.SEAT_NOT_FOUND));
+                .map(
+                        booking -> {
+                            // BookedSeat를 통해 Seat 정보 가져오기
+                            BookedSeat bookedSeat =
+                                    bookedSeatRepository
+                                            .findByBooking(booking)
+                                            .orElseThrow(
+                                                    () ->
+                                                            new CustomException(
+                                                                    ErrorCode.SEAT_NOT_FOUND));
 
-                    return BookingResponseDto.from(booking, bookedSeat.getSeat());
-                })
-            .collect(Collectors.toList());
+                            return BookingResponseDto.from(booking, bookedSeat.getSeat());
+                        })
+                .collect(Collectors.toList());
     }
 
     @Transactional
@@ -292,18 +292,18 @@ public class BookingService {
 
         // 만료된 예약들 조회 (PENDING 상태 & 5분 지남)
         List<Booking> expiredBookings =
-            bookingRepository.findByStatusAndCreatedAtBefore(
-                BookingStatus.PENDING, fiveMinutesAgo);
+                bookingRepository.findByStatusAndCreatedAtBefore(
+                        BookingStatus.PENDING, fiveMinutesAgo);
 
         // 하나씩 취소 처리
         for (Booking booking : expiredBookings) {
             BookedSeat bookedSeat =
-                bookedSeatRepository
-                    .findByBooking(booking)
-                    .orElseThrow(() -> new CustomException(ErrorCode.SEAT_NOT_FOUND));
+                    bookedSeatRepository
+                            .findByBooking(booking)
+                            .orElseThrow(() -> new CustomException(ErrorCode.SEAT_NOT_FOUND));
             cancelPendingBooking(booking, bookedSeat);
-            waitingQueueService.popQueue(bookedSeat.getSeat().getEvent().getEventId(),
-                booking.getUsers().getUserId());
+            waitingQueueService.popQueue(
+                    bookedSeat.getSeat().getEvent().getEventId(), booking.getUsers().getUserId());
         }
     }
 }

--- a/src/main/java/com/DBP/ticketing_backend/domain/event/controller/EventController.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/event/controller/EventController.java
@@ -37,9 +37,9 @@ public class EventController {
     private final EventService eventService;
 
     @Operation(
-        summary = "이벤트 생성",
-        description =
-            """
+            summary = "이벤트 생성",
+            description =
+                    """
             호스트가 이벤트 정보를 입력하여 새로운 이벤트를 생성합니다.
 
             **권한:**
@@ -47,8 +47,7 @@ public class EventController {
 
             **참고:**
             - 요청 본문에 이벤트 정보를 포함해야 합니다.
-            """
-    )
+            """)
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "이벤트 생성 성공"),
         @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터"),
@@ -62,9 +61,9 @@ public class EventController {
     }
 
     @Operation(
-        summary = "이벤트 목록 조회",
-        description =
-            """
+            summary = "이벤트 목록 조회",
+            description =
+                    """
             이벤트 상태에 따라 이벤트 목록을 조회합니다.
 
             **권한:**
@@ -72,14 +71,12 @@ public class EventController {
 
             **참고:**
             - `status` 파라미터를 사용하여 특정 상태의 이벤트만 필터링할 수 있습니다.
-            """
-    )
+            """)
     @ApiResponses({
         @ApiResponse(
-            responseCode = "200",
-            description = "조회 성공",
-            content = @Content(schema = @Schema(implementation = EventListResponseDto.class))
-        ),
+                responseCode = "200",
+                description = "조회 성공",
+                content = @Content(schema = @Schema(implementation = EventListResponseDto.class))),
         @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터")
     })
     @GetMapping
@@ -89,9 +86,9 @@ public class EventController {
     }
 
     @Operation(
-        summary = "이벤트 상세 조회",
-        description =
-            """
+            summary = "이벤트 상세 조회",
+            description =
+                    """
             이벤트 ID를 사용하여 특정 이벤트의 상세 정보를 조회합니다.
 
             **권한:**
@@ -99,14 +96,13 @@ public class EventController {
 
             **참고:**
             - 유효하지 않은 이벤트 ID를 전달하면 404 에러가 반환됩니다.
-            """
-    )
+            """)
     @ApiResponses({
         @ApiResponse(
-            responseCode = "200",
-            description = "조회 성공",
-            content = @Content(schema = @Schema(implementation = EventDetailResponseDto.class))
-        ),
+                responseCode = "200",
+                description = "조회 성공",
+                content =
+                        @Content(schema = @Schema(implementation = EventDetailResponseDto.class))),
         @ApiResponse(responseCode = "404", description = "이벤트를 찾을 수 없음")
     })
     @GetMapping("/{eventId}")

--- a/src/main/java/com/DBP/ticketing_backend/domain/event/controller/EventController.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/event/controller/EventController.java
@@ -8,6 +8,10 @@ import com.DBP.ticketing_backend.domain.event.enums.EventStatus;
 import com.DBP.ticketing_backend.domain.event.service.EventService;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 import lombok.RequiredArgsConstructor;
@@ -32,7 +36,24 @@ public class EventController {
 
     private final EventService eventService;
 
-    @Operation(summary = "이벤트 생성", description = "호스트가 이벤트 정보를 입력하여 이벤트를 생성합니다.")
+    @Operation(
+        summary = "이벤트 생성",
+        description =
+            """
+            호스트가 이벤트 정보를 입력하여 새로운 이벤트를 생성합니다.
+
+            **권한:**
+            - 인증된 사용자만 접근 가능
+
+            **참고:**
+            - 요청 본문에 이벤트 정보를 포함해야 합니다.
+            """
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "이벤트 생성 성공"),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터"),
+        @ApiResponse(responseCode = "401", description = "인증되지 않은 요청")
+    })
     @PostMapping
     public ResponseEntity<Long> createEvent(
             @RequestBody CreateEventRequestDto createEventRequestDto,
@@ -40,14 +61,54 @@ public class EventController {
         return ResponseEntity.ok(eventService.createEvent(createEventRequestDto, usersDetails));
     }
 
-    @Operation(summary = "이벤트 조회", description = "이벤트 상태에 따라 조회합니다")
+    @Operation(
+        summary = "이벤트 목록 조회",
+        description =
+            """
+            이벤트 상태에 따라 이벤트 목록을 조회합니다.
+
+            **권한:**
+            - 모든 사용자 접근 가능
+
+            **참고:**
+            - `status` 파라미터를 사용하여 특정 상태의 이벤트만 필터링할 수 있습니다.
+            """
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "조회 성공",
+            content = @Content(schema = @Schema(implementation = EventListResponseDto.class))
+        ),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터")
+    })
     @GetMapping
     public ResponseEntity<List<EventListResponseDto>> getEvents(
             @RequestParam(required = false) EventStatus status) {
         return ResponseEntity.ok(eventService.getEvents(status));
     }
 
-    @Operation(summary = "이벤트 조회", description = "이벤트 아이디를 통해 이벤트를 조회합니다.")
+    @Operation(
+        summary = "이벤트 상세 조회",
+        description =
+            """
+            이벤트 ID를 사용하여 특정 이벤트의 상세 정보를 조회합니다.
+
+            **권한:**
+            - 모든 사용자 접근 가능
+
+            **참고:**
+            - 유효하지 않은 이벤트 ID를 전달하면 404 에러가 반환됩니다.
+            """
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "조회 성공",
+            content = @Content(schema = @Schema(implementation = EventDetailResponseDto.class))
+        ),
+        @ApiResponse(responseCode = "404", description = "이벤트를 찾을 수 없음")
+    })
     @GetMapping("/{eventId}")
     public ResponseEntity<EventDetailResponseDto> getEvent(@PathVariable Long eventId) {
         return ResponseEntity.ok(eventService.getEvent(eventId));

--- a/src/main/java/com/DBP/ticketing_backend/domain/event/repository/EventRepository.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/event/repository/EventRepository.java
@@ -19,4 +19,6 @@ public interface EventRepository extends JpaRepository<Event, Long> {
     List<Event> findAllByStatusInOrderByCreatedAtDesc(List<EventStatus> statuses);
 
     List<Event> findAllByStatus(EventStatus eventStatus);
+
+    List<Event> findByStatusAndDateBefore(EventStatus eventStatus, LocalDateTime now);
 }

--- a/src/main/java/com/DBP/ticketing_backend/domain/event/repository/EventRepository.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/event/repository/EventRepository.java
@@ -17,4 +17,6 @@ public interface EventRepository extends JpaRepository<Event, Long> {
     List<Event> findAllByStatusOrderByCreatedAtDesc(EventStatus status);
 
     List<Event> findAllByStatusInOrderByCreatedAtDesc(List<EventStatus> statuses);
+
+    List<Event> findAllByStatus(EventStatus eventStatus);
 }

--- a/src/main/java/com/DBP/ticketing_backend/domain/event/scheduler/EventScheduler.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/event/scheduler/EventScheduler.java
@@ -3,15 +3,14 @@ package com.DBP.ticketing_backend.domain.event.scheduler;
 import com.DBP.ticketing_backend.domain.event.entity.Event;
 import com.DBP.ticketing_backend.domain.event.enums.EventStatus;
 import com.DBP.ticketing_backend.domain.event.repository.EventRepository;
-
 import com.DBP.ticketing_backend.domain.event.service.EventService;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -24,12 +23,14 @@ public class EventScheduler {
     private final EventRepository eventRepository;
     private final EventService eventService;
     private final RedisTemplate<String, String> redisTemplate;
+
     @Scheduled(cron = "0 * * * * *")
     public void openTicketingEvents() {
         LocalDateTime now = LocalDateTime.now();
 
-        List<Event> eventsToOpen = eventRepository.findByStatusAndTicketingStartAtLessThanEqual(
-            EventStatus.SCHEDULED, now);
+        List<Event> eventsToOpen =
+                eventRepository.findByStatusAndTicketingStartAtLessThanEqual(
+                        EventStatus.SCHEDULED, now);
 
         if (eventsToOpen.isEmpty()) {
             return;

--- a/src/main/java/com/DBP/ticketing_backend/domain/event/scheduler/EventScheduler.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/event/scheduler/EventScheduler.java
@@ -4,9 +4,11 @@ import com.DBP.ticketing_backend.domain.event.entity.Event;
 import com.DBP.ticketing_backend.domain.event.enums.EventStatus;
 import com.DBP.ticketing_backend.domain.event.repository.EventRepository;
 
+import com.DBP.ticketing_backend.domain.event.service.EventService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,26 +22,42 @@ import java.util.List;
 public class EventScheduler {
 
     private final EventRepository eventRepository;
-
+    private final EventService eventService;
+    private final RedisTemplate<String, String> redisTemplate;
     @Scheduled(cron = "0 * * * * *")
-    @Transactional
     public void openTicketingEvents() {
         LocalDateTime now = LocalDateTime.now();
 
-        List<Event> eventsToOpen =
-                eventRepository.findByStatusAndTicketingStartAtLessThanEqual(
-                        EventStatus.SCHEDULED, now);
+        List<Event> eventsToOpen = eventRepository.findByStatusAndTicketingStartAtLessThanEqual(
+            EventStatus.SCHEDULED, now);
 
         if (eventsToOpen.isEmpty()) {
             return;
         }
 
         for (Event event : eventsToOpen) {
-            event.updateStatus(EventStatus.OPEN);
-            log.info(
-                    "Event ID {} is now OPEN! (Scheduled Time: {})",
-                    event.getEventId(),
-                    event.getTicketingStartAt());
+            try {
+                eventService.openEvent(event.getEventId());
+
+                log.info("Event ID {} is now OPEN!", event.getEventId());
+            } catch (Exception e) {
+                log.error("Event {} 오픈 처리 실패", event.getEventId(), e);
+            }
+        }
+    }
+
+    @Scheduled(cron = "0 * * * * *")
+    public void closeEndedEvents() {
+        LocalDateTime now = LocalDateTime.now();
+        List<Event> endedEvents = eventRepository.findByStatusAndDateBefore(EventStatus.OPEN, now);
+
+        for (Event event : endedEvents) {
+            try {
+                // 서비스에게 "이거 닫아줘"라고 위임
+                eventService.closeEndedEvent(event.getEventId());
+            } catch (Exception e) {
+                log.error("Event {} 자동 종료 실패", event.getEventId(), e);
+            }
         }
     }
 }

--- a/src/main/java/com/DBP/ticketing_backend/domain/event/service/EventService.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/event/service/EventService.java
@@ -24,6 +24,7 @@ import com.DBP.ticketing_backend.global.exception.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -42,6 +43,7 @@ public class EventService {
     private final PlaceRepository placeRepository;
     private final SeatTemplateRepository seatTemplateRepository;
     private final SeatRepository seatRepository;
+    private final RedisTemplate<String, String> redisTemplate;
 
     @Transactional
     public Long createEvent(CreateEventRequestDto requestDto, UsersDetails usersDetails) {
@@ -159,5 +161,56 @@ public class EventService {
                         .orElseThrow(() -> new CustomException(ErrorCode.EVENT_NOT_FOUND));
 
         return EventDetailResponseDto.from(event);
+    }
+
+    @Transactional
+    public void updateEventStatus(Long eventId, EventStatus newStatus) {
+        Event event = eventRepository.findById(eventId)
+            .orElseThrow(() -> new CustomException(ErrorCode.EVENT_NOT_FOUND));
+
+        // 1. DB 상태 변경
+        event.updateStatus(newStatus);
+
+        // 2. 예매 불가능 상태가 되면 Redis 대기열 데이터 삭제 (메모리 확보)
+        if (newStatus == EventStatus.CLOSED ||
+            newStatus == EventStatus.CANCELLED ||
+            newStatus == EventStatus.COMPLETED) {
+
+            // 대기열(Waiting) 삭제
+            redisTemplate.delete("waiting_queue:" + eventId);
+
+            // 입장객(Active) 삭제
+            // (선택사항: 이미 들어온 사람은 결제하게 둘 건지, 강제로 쫓아낼 건지 정책에 따라 결정)
+            // 보통 취소/종료면 쫓아내는 게 맞고, 마감(CLOSED)이면 들어온 사람은 결제하게 둬도 됨.
+            redisTemplate.delete("active_tokens:" + eventId);
+        }
+    }
+
+    @Transactional
+    public void openEvent(Long eventId) {
+        Event event = eventRepository.findById(eventId)
+            .orElseThrow(() -> new CustomException(ErrorCode.EVENT_NOT_FOUND));
+
+        event.updateStatus(EventStatus.OPEN);
+    }
+
+    @Transactional
+    public void closeEndedEvent(Long eventId) {
+        Event event = eventRepository.findById(eventId)
+            .orElseThrow(() -> new CustomException(ErrorCode.EVENT_NOT_FOUND));
+
+        // 공통 로직 호출 (CLOSED로 변경)
+        processStatusChange(event, EventStatus.CLOSED);
+    }
+
+    private void processStatusChange(Event event, EventStatus status) {
+        event.updateStatus(status);
+
+        // 종료/취소/마감 상태라면 대기열 삭제
+        if (status == EventStatus.CLOSED || status == EventStatus.CANCELLED || status == EventStatus.COMPLETED) {
+            String eventIdStr = event.getEventId().toString();
+            redisTemplate.delete("waiting_queue:" + eventIdStr);
+            redisTemplate.delete("active_tokens:" + eventIdStr);
+        }
     }
 }

--- a/src/main/java/com/DBP/ticketing_backend/domain/event/service/EventService.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/event/service/EventService.java
@@ -165,16 +165,18 @@ public class EventService {
 
     @Transactional
     public void updateEventStatus(Long eventId, EventStatus newStatus) {
-        Event event = eventRepository.findById(eventId)
-            .orElseThrow(() -> new CustomException(ErrorCode.EVENT_NOT_FOUND));
+        Event event =
+                eventRepository
+                        .findById(eventId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.EVENT_NOT_FOUND));
 
         // 1. DB 상태 변경
         event.updateStatus(newStatus);
 
         // 2. 예매 불가능 상태가 되면 Redis 대기열 데이터 삭제 (메모리 확보)
-        if (newStatus == EventStatus.CLOSED ||
-            newStatus == EventStatus.CANCELLED ||
-            newStatus == EventStatus.COMPLETED) {
+        if (newStatus == EventStatus.CLOSED
+                || newStatus == EventStatus.CANCELLED
+                || newStatus == EventStatus.COMPLETED) {
 
             // 대기열(Waiting) 삭제
             redisTemplate.delete("waiting_queue:" + eventId);
@@ -188,16 +190,20 @@ public class EventService {
 
     @Transactional
     public void openEvent(Long eventId) {
-        Event event = eventRepository.findById(eventId)
-            .orElseThrow(() -> new CustomException(ErrorCode.EVENT_NOT_FOUND));
+        Event event =
+                eventRepository
+                        .findById(eventId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.EVENT_NOT_FOUND));
 
         event.updateStatus(EventStatus.OPEN);
     }
 
     @Transactional
     public void closeEndedEvent(Long eventId) {
-        Event event = eventRepository.findById(eventId)
-            .orElseThrow(() -> new CustomException(ErrorCode.EVENT_NOT_FOUND));
+        Event event =
+                eventRepository
+                        .findById(eventId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.EVENT_NOT_FOUND));
 
         // 공통 로직 호출 (CLOSED로 변경)
         processStatusChange(event, EventStatus.CLOSED);
@@ -207,7 +213,9 @@ public class EventService {
         event.updateStatus(status);
 
         // 종료/취소/마감 상태라면 대기열 삭제
-        if (status == EventStatus.CLOSED || status == EventStatus.CANCELLED || status == EventStatus.COMPLETED) {
+        if (status == EventStatus.CLOSED
+                || status == EventStatus.CANCELLED
+                || status == EventStatus.COMPLETED) {
             String eventIdStr = event.getEventId().toString();
             redisTemplate.delete("waiting_queue:" + eventIdStr);
             redisTemplate.delete("active_tokens:" + eventIdStr);

--- a/src/main/java/com/DBP/ticketing_backend/domain/place/controller/PlaceController.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/place/controller/PlaceController.java
@@ -6,6 +6,10 @@ import com.DBP.ticketing_backend.domain.place.dto.PlaceResponseDto;
 import com.DBP.ticketing_backend.domain.place.service.PlaceService;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 import lombok.RequiredArgsConstructor;
@@ -28,7 +32,24 @@ public class PlaceController {
 
     private final PlaceService placeService;
 
-    @Operation(summary = "장소 생성", description = "장소를 생성합니다.")
+    @Operation(
+        summary = "장소 생성",
+        description =
+            """
+            새로운 장소를 생성합니다.
+
+            **권한:**
+            - 관리자 권한이 필요합니다.
+
+            **참고:**
+            - 요청 본문에 장소 정보를 포함해야 합니다.
+            """
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "장소 생성 성공"),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터"),
+        @ApiResponse(responseCode = "401", description = "인증되지 않은 요청")
+    })
     @PostMapping("/create")
     public ResponseEntity<Long> createPlace(
             @RequestBody CreatePlaceRequestDto createPlaceRequestDto,
@@ -36,7 +57,28 @@ public class PlaceController {
         return ResponseEntity.ok(placeService.createPlace(createPlaceRequestDto, usersDetails));
     }
 
-    @Operation(summary = "장소 조회", description = "장소 아이디로 장소를 조회합니다.")
+    @Operation(
+        summary = "장소 조회",
+        description =
+            """
+            장소 ID를 사용하여 특정 장소의 정보를 조회합니다.
+
+            **권한:**
+            - 관리자 권한이 필요합니다.
+
+            **참고:**
+            - 유효하지 않은 장소 ID를 전달하면 404 에러가 반환됩니다.
+            """
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "조회 성공",
+            content = @Content(schema = @Schema(implementation = PlaceResponseDto.class))
+        ),
+        @ApiResponse(responseCode = "404", description = "장소를 찾을 수 없음"),
+        @ApiResponse(responseCode = "401", description = "인증되지 않은 요청")
+    })
     @GetMapping("/{placeId}")
     public ResponseEntity<PlaceResponseDto> getPlace(
             @PathVariable("placeId") Long placeId,
@@ -44,7 +86,24 @@ public class PlaceController {
         return ResponseEntity.ok(placeService.getPlace(placeId, usersDetails));
     }
 
-    @Operation(summary = "장소 삭제", description = "장소 아이디로 장소를 삭제합니다.")
+    @Operation(
+        summary = "장소 삭제",
+        description =
+            """
+            장소 ID를 사용하여 특정 장소를 삭제합니다.
+
+            **권한:**
+            - 관리자 권한이 필요합니다.
+
+            **참고:**
+            - 유효하지 않은 장소 ID를 전달하면 404 에러가 반환됩니다.
+            """
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "장소 삭제 성공"),
+        @ApiResponse(responseCode = "404", description = "장소를 찾을 수 없음"),
+        @ApiResponse(responseCode = "401", description = "인증되지 않은 요청")
+    })
     @DeleteMapping("/{placeId}")
     public ResponseEntity<Void> deletePlace(
             @PathVariable("placeId") Long placeId,

--- a/src/main/java/com/DBP/ticketing_backend/domain/place/controller/PlaceController.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/place/controller/PlaceController.java
@@ -33,9 +33,9 @@ public class PlaceController {
     private final PlaceService placeService;
 
     @Operation(
-        summary = "장소 생성",
-        description =
-            """
+            summary = "장소 생성",
+            description =
+                    """
             새로운 장소를 생성합니다.
 
             **권한:**
@@ -43,8 +43,7 @@ public class PlaceController {
 
             **참고:**
             - 요청 본문에 장소 정보를 포함해야 합니다.
-            """
-    )
+            """)
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "장소 생성 성공"),
         @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터"),
@@ -58,9 +57,9 @@ public class PlaceController {
     }
 
     @Operation(
-        summary = "장소 조회",
-        description =
-            """
+            summary = "장소 조회",
+            description =
+                    """
             장소 ID를 사용하여 특정 장소의 정보를 조회합니다.
 
             **권한:**
@@ -68,14 +67,12 @@ public class PlaceController {
 
             **참고:**
             - 유효하지 않은 장소 ID를 전달하면 404 에러가 반환됩니다.
-            """
-    )
+            """)
     @ApiResponses({
         @ApiResponse(
-            responseCode = "200",
-            description = "조회 성공",
-            content = @Content(schema = @Schema(implementation = PlaceResponseDto.class))
-        ),
+                responseCode = "200",
+                description = "조회 성공",
+                content = @Content(schema = @Schema(implementation = PlaceResponseDto.class))),
         @ApiResponse(responseCode = "404", description = "장소를 찾을 수 없음"),
         @ApiResponse(responseCode = "401", description = "인증되지 않은 요청")
     })
@@ -87,9 +84,9 @@ public class PlaceController {
     }
 
     @Operation(
-        summary = "장소 삭제",
-        description =
-            """
+            summary = "장소 삭제",
+            description =
+                    """
             장소 ID를 사용하여 특정 장소를 삭제합니다.
 
             **권한:**
@@ -97,8 +94,7 @@ public class PlaceController {
 
             **참고:**
             - 유효하지 않은 장소 ID를 전달하면 404 에러가 반환됩니다.
-            """
-    )
+            """)
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "장소 삭제 성공"),
         @ApiResponse(responseCode = "404", description = "장소를 찾을 수 없음"),

--- a/src/main/java/com/DBP/ticketing_backend/domain/queue/controller/QueueController.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/queue/controller/QueueController.java
@@ -1,0 +1,46 @@
+package com.DBP.ticketing_backend.domain.queue.controller;
+
+import com.DBP.ticketing_backend.domain.auth.dto.UsersDetails;
+import com.DBP.ticketing_backend.domain.queue.dto.QueueResponseDto;
+import com.DBP.ticketing_backend.domain.queue.service.WaitingQueueService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/queue")
+@RequiredArgsConstructor
+@Tag(name = " 대기열 API", description = "대기열 진입 및 순서 확인 API")
+public class QueueController {
+
+    private final WaitingQueueService waitingQueueService;
+
+    @Operation(summary = "대기열 진입", description = "특정 이벤트의 대기열에 줄을 섭니다.")
+    @PostMapping("/{eventId}")
+    public ResponseEntity<String> joinQueue(
+        @PathVariable Long eventId,
+        @AuthenticationPrincipal UsersDetails usersDetails) {
+
+        waitingQueueService.registerQueue(eventId, usersDetails.getUserId());
+        return ResponseEntity.ok("대기열에 등록되었습니다.");
+    }
+
+    @Operation(summary = "내 순서 확인", description = "현재 내 대기 순번과 입장 가능 여부를 조회합니다.")
+    @GetMapping("/rank/{eventId}")
+    public ResponseEntity<QueueResponseDto> getRank(
+        @PathVariable Long eventId,
+        @AuthenticationPrincipal UsersDetails usersDetails) {
+
+        Long rank = waitingQueueService.getRank(eventId, usersDetails.getUserId());
+        boolean isActive = waitingQueueService.isActive(eventId, usersDetails.getUserId());
+
+        return ResponseEntity.ok(new QueueResponseDto(rank, isActive));
+    }
+}

--- a/src/main/java/com/DBP/ticketing_backend/domain/queue/controller/QueueController.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/queue/controller/QueueController.java
@@ -4,6 +4,8 @@ import com.DBP.ticketing_backend.domain.auth.dto.UsersDetails;
 import com.DBP.ticketing_backend.domain.queue.dto.QueueResponseDto;
 import com.DBP.ticketing_backend.domain.queue.service.WaitingQueueService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -22,7 +24,25 @@ public class QueueController {
 
     private final WaitingQueueService waitingQueueService;
 
-    @Operation(summary = "대기열 진입", description = "특정 이벤트의 대기열에 줄을 섭니다.")
+    @Operation(
+        summary = "대기열 진입",
+        description =
+            """
+            특정 이벤트의 대기열에 줄을 섭니다.
+
+            **권한:**
+            - 인증된 사용자만 접근 가능
+
+            **참고:**
+            - 이벤트 ID가 유효하지 않으면 404 에러가 반환됩니다.
+            - 이미 대기열에 등록된 경우 중복 등록은 허용되지 않습니다.
+            """
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "대기열 등록 성공"),
+        @ApiResponse(responseCode = "401", description = "인증되지 않은 요청"),
+        @ApiResponse(responseCode = "404", description = "이벤트를 찾을 수 없음")
+    })
     @PostMapping("/{eventId}")
     public ResponseEntity<String> joinQueue(
         @PathVariable Long eventId,
@@ -32,8 +52,24 @@ public class QueueController {
         return ResponseEntity.ok("대기열에 등록되었습니다.");
     }
 
-    @Operation(summary = "내 순서 확인", description = "현재 내 대기 순번과 입장 가능 여부를 조회합니다.")
-    @GetMapping("/rank/{eventId}")
+    @Operation(
+        summary = "내 순서 확인",
+        description =
+            """
+            현재 내 대기 순번과 입장 가능 여부를 조회합니다.
+
+            **반환 정보:**
+            - 현재 대기 순번
+            - 입장 가능 여부 (true/false)
+
+            **권한:**
+            - 인증된 사용자만 접근 가능
+
+            **참고:**
+            - 이벤트 ID가 유효하지 않으면 404 에러가 반환됩니다.
+            - 대기열에 등록되지 않은 경우 순번은 null로 반환됩니다.
+            """
+    )    @GetMapping("/rank/{eventId}")
     public ResponseEntity<QueueResponseDto> getRank(
         @PathVariable Long eventId,
         @AuthenticationPrincipal UsersDetails usersDetails) {

--- a/src/main/java/com/DBP/ticketing_backend/domain/queue/controller/QueueController.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/queue/controller/QueueController.java
@@ -28,9 +28,9 @@ public class QueueController {
     private final WaitingQueueService waitingQueueService;
 
     @Operation(
-        summary = "대기열 진입",
-        description =
-            """
+            summary = "대기열 진입",
+            description =
+                    """
             특정 이벤트의 대기열에 줄을 섭니다.
 
             **권한:**
@@ -39,8 +39,7 @@ public class QueueController {
             **참고:**
             - 이벤트 ID가 유효하지 않으면 404 에러가 반환됩니다.
             - 이미 대기열에 등록된 경우 중복 등록은 허용되지 않습니다.
-            """
-    )
+            """)
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "대기열 등록 성공"),
         @ApiResponse(responseCode = "401", description = "인증되지 않은 요청"),
@@ -55,9 +54,9 @@ public class QueueController {
     }
 
     @Operation(
-        summary = "내 순서 확인",
-        description =
-            """
+            summary = "내 순서 확인",
+            description =
+                    """
             현재 내 대기 순번과 입장 가능 여부를 조회합니다.
 
             **반환 정보:**
@@ -70,8 +69,8 @@ public class QueueController {
             **참고:**
             - 이벤트 ID가 유효하지 않으면 404 에러가 반환됩니다.
             - 대기열에 등록되지 않은 경우 순번은 null로 반환됩니다.
-            """
-    )    @GetMapping("/rank/{eventId}")
+            """)
+    @GetMapping("/rank/{eventId}")
     public ResponseEntity<QueueResponseDto> getRank(
             @PathVariable Long eventId, @AuthenticationPrincipal UsersDetails usersDetails) {
 

--- a/src/main/java/com/DBP/ticketing_backend/domain/queue/controller/QueueController.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/queue/controller/QueueController.java
@@ -3,9 +3,12 @@ package com.DBP.ticketing_backend.domain.queue.controller;
 import com.DBP.ticketing_backend.domain.auth.dto.UsersDetails;
 import com.DBP.ticketing_backend.domain.queue.dto.QueueResponseDto;
 import com.DBP.ticketing_backend.domain.queue.service.WaitingQueueService;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -25,8 +28,7 @@ public class QueueController {
     @Operation(summary = "대기열 진입", description = "특정 이벤트의 대기열에 줄을 섭니다.")
     @PostMapping("/{eventId}")
     public ResponseEntity<String> joinQueue(
-        @PathVariable Long eventId,
-        @AuthenticationPrincipal UsersDetails usersDetails) {
+            @PathVariable Long eventId, @AuthenticationPrincipal UsersDetails usersDetails) {
 
         waitingQueueService.registerQueue(eventId, usersDetails.getUserId());
         return ResponseEntity.ok("대기열에 등록되었습니다.");
@@ -35,8 +37,7 @@ public class QueueController {
     @Operation(summary = "내 순서 확인", description = "현재 내 대기 순번과 입장 가능 여부를 조회합니다.")
     @GetMapping("/rank/{eventId}")
     public ResponseEntity<QueueResponseDto> getRank(
-        @PathVariable Long eventId,
-        @AuthenticationPrincipal UsersDetails usersDetails) {
+            @PathVariable Long eventId, @AuthenticationPrincipal UsersDetails usersDetails) {
 
         Long rank = waitingQueueService.getRank(eventId, usersDetails.getUserId());
         boolean isActive = waitingQueueService.isActive(eventId, usersDetails.getUserId());

--- a/src/main/java/com/DBP/ticketing_backend/domain/queue/dto/QueueResponseDto.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/queue/dto/QueueResponseDto.java
@@ -1,0 +1,15 @@
+package com.DBP.ticketing_backend.domain.queue.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class QueueResponseDto {
+    private Long rank;      // 내 대기 순번
+    private boolean active; // 입장 가능 여부
+}

--- a/src/main/java/com/DBP/ticketing_backend/domain/queue/dto/QueueResponseDto.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/queue/dto/QueueResponseDto.java
@@ -10,6 +10,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class QueueResponseDto {
-    private Long rank;      // 내 대기 순번
+    private Long rank; // 내 대기 순번
     private boolean active; // 입장 가능 여부
 }

--- a/src/main/java/com/DBP/ticketing_backend/domain/queue/scheduler/QueueScheduler.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/queue/scheduler/QueueScheduler.java
@@ -1,0 +1,86 @@
+package com.DBP.ticketing_backend.domain.queue.scheduler;
+
+import com.DBP.ticketing_backend.domain.event.entity.Event;
+import com.DBP.ticketing_backend.domain.event.enums.EventStatus;
+import com.DBP.ticketing_backend.domain.event.repository.EventRepository;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class QueueScheduler {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final EventRepository eventRepository;
+
+    private static final long MAX_USERS = 100L; // 최대 동시 접속 인원
+    private static final long ACTIVE_USER_TTL = 5 * 60 * 1000;   // 5분
+    private static final long WAITING_USER_TTL = 60 * 60 * 1000; // 1시간
+
+    @Scheduled(fixedDelay = 1000) // 1초마다 실행
+    public void scheduleQueue() {
+        // OPEN 상태인 이벤트만 관리
+        List<Event> openEvents = eventRepository.findAllByStatus(EventStatus.OPEN);
+
+        for (Event event : openEvents) {
+            Long eventId = event.getEventId();
+            String waitingKey = "waiting_queue:" + eventId;
+            String activeKey = "active_tokens:" + eventId;
+
+            long now = System.currentTimeMillis();
+
+            // =====================================================
+            // 1. [청소] Waiting Queue: 1시간 넘게 대기한 유저 삭제 (Ghost 제거)
+            // =====================================================
+            long waitingCutoff = now - WAITING_USER_TTL;
+            redisTemplate.opsForZSet().removeRangeByScore(waitingKey, 0, waitingCutoff);
+
+            // =====================================================
+            // 2. [청소] Active Queue: 5분 지난 Active 유저 자동 퇴장 (Time-out)
+            // =====================================================
+            long activeCutoff = now - ACTIVE_USER_TTL;
+            Long evictedCount = redisTemplate.opsForZSet().removeRangeByScore(activeKey, 0, activeCutoff);
+
+            if (evictedCount != null && evictedCount > 0) {
+                log.info("Event {} : 시간 초과로 {}명 자동 퇴장 처리됨.", eventId, evictedCount);
+            }
+
+            // =====================================================
+            // 3. [입장] 빈자리만큼 대기열에서 입장 (Move Waiting -> Active)
+            // =====================================================
+            // 현재 Active 인원 확인
+            Long currentActive = redisTemplate.opsForZSet().zCard(activeKey);
+            if (currentActive == null) currentActive = 0L;
+
+            long availableSlots = MAX_USERS - currentActive;
+
+            // 자리가 남았고, 대기자가 있다면 입장
+            if (availableSlots > 0) {
+                // 대기열 앞에서부터 가져오기
+                Set<String> userIds = redisTemplate.opsForZSet().range(waitingKey, 0, availableSlots - 1);
+
+                if (userIds != null && !userIds.isEmpty()) {
+                    for (String userId : userIds) {
+                        // 트랜잭션 처리 권장되나, 간단히 순차 실행
+
+                        // A. 대기열 제거
+                        redisTemplate.opsForZSet().remove(waitingKey, userId);
+
+                        // B. 활성열 추가 (Score = 현재 시간 -> 5분 타이머 시작)
+                        redisTemplate.opsForZSet().add(activeKey, userId, System.currentTimeMillis());
+
+                        log.info("Event {} : 유저 {} 입장 성공! (현재 접속자: {}명)", eventId, userId, currentActive + 1);
+                        currentActive++;
+                    }
+                }
+            }
+        }
+    }
+
+}

--- a/src/main/java/com/DBP/ticketing_backend/domain/queue/service/WaitingQueueService.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/queue/service/WaitingQueueService.java
@@ -1,0 +1,46 @@
+package com.DBP.ticketing_backend.domain.queue.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class WaitingQueueService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    // 1. 대기열 등록
+    public void registerQueue(Long eventId, Long userId) {
+        String key = "waiting_queue:" + eventId;
+        long timestamp = System.currentTimeMillis();
+
+        // ZADD key score member (점수는 접속 시간)
+        // 이미 줄을 선 유저라면 기존 점수 유지
+        redisTemplate.opsForZSet().add(key, userId.toString(), timestamp);
+    }
+
+    // 2. 내 순서 조회
+    public Long getRank(Long eventId, Long userId) {
+        String key = "waiting_queue:" + eventId;
+        Long rank = redisTemplate.opsForZSet().rank(key, userId.toString());
+
+        // 0등부터 시작하므로 +1 처리
+        return (rank != null) ? rank + 1 : null;
+    }
+
+    // 3. 입장 가능 여부 확인 (isActive)
+    // 인터셉터에서 호출됨
+    public boolean isActive(Long eventId, Long userId) {
+        String key = "active_tokens:" + eventId;
+        // 점수(입장시간)가 존재하면 Active 상태임
+        Double score = redisTemplate.opsForZSet().score(key, userId.toString());
+        return score != null;
+    }
+
+    // 4. 퇴장 처리 (결제/취소 시 호출)
+    public void popQueue(Long eventId, Long userId) {
+        String key = "active_tokens:" + eventId;
+        redisTemplate.opsForZSet().remove(key, userId.toString());
+    }
+}

--- a/src/main/java/com/DBP/ticketing_backend/domain/queue/service/WaitingQueueService.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/queue/service/WaitingQueueService.java
@@ -1,6 +1,7 @@
 package com.DBP.ticketing_backend.domain.queue.service;
 
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/com/DBP/ticketing_backend/domain/seat/controller/SeatController.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/seat/controller/SeatController.java
@@ -4,6 +4,10 @@ import com.DBP.ticketing_backend.domain.seat.dto.SeatResponseDto;
 import com.DBP.ticketing_backend.domain.seat.service.SeatService;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 import lombok.RequiredArgsConstructor;
@@ -24,8 +28,28 @@ public class SeatController {
 
     private final SeatService seatService;
 
+    @Operation(
+        summary = "좌석 조회",
+        description =
+            """
+            특정 이벤트의 전체 좌석 상태를 조회합니다.
+
+            **권한:**
+            - 모든 사용자 접근 가능
+
+            **참고:**
+            - 이벤트 ID가 유효하지 않으면 404 에러가 반환됩니다.
+            """
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "조회 성공",
+            content = @Content(schema = @Schema(implementation = SeatResponseDto.class))
+        ),
+        @ApiResponse(responseCode = "404", description = "이벤트를 찾을 수 없음")
+    })
     @GetMapping("/{eventId}")
-    @Operation(summary = "좌석 조회", description = "특정 이벤트의 전체 좌석 상태를 조회합니다.")
     public ResponseEntity<List<SeatResponseDto>> getSeats(@PathVariable Long eventId) {
         return ResponseEntity.ok(seatService.getSeatsByEvent(eventId));
     }

--- a/src/main/java/com/DBP/ticketing_backend/domain/seat/controller/SeatController.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/seat/controller/SeatController.java
@@ -29,9 +29,9 @@ public class SeatController {
     private final SeatService seatService;
 
     @Operation(
-        summary = "좌석 조회",
-        description =
-            """
+            summary = "좌석 조회",
+            description =
+                    """
             특정 이벤트의 전체 좌석 상태를 조회합니다.
 
             **권한:**
@@ -39,14 +39,12 @@ public class SeatController {
 
             **참고:**
             - 이벤트 ID가 유효하지 않으면 404 에러가 반환됩니다.
-            """
-    )
+            """)
     @ApiResponses({
         @ApiResponse(
-            responseCode = "200",
-            description = "조회 성공",
-            content = @Content(schema = @Schema(implementation = SeatResponseDto.class))
-        ),
+                responseCode = "200",
+                description = "조회 성공",
+                content = @Content(schema = @Schema(implementation = SeatResponseDto.class))),
         @ApiResponse(responseCode = "404", description = "이벤트를 찾을 수 없음")
     })
     @GetMapping("/{eventId}")

--- a/src/main/java/com/DBP/ticketing_backend/domain/seat/repository/SeatRepository.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/seat/repository/SeatRepository.java
@@ -29,7 +29,7 @@ public interface SeatRepository extends JpaRepository<Seat, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query(
             "select s from Seat s where s.event.eventId = :eventId and s.status = :status order by"
-                + " s.seatId asc limit 1")
+                    + " s.seatId asc limit 1")
     Optional<Seat> findFirstByEvent_EventIdAndStatusOrderBySeatIdAscWithLock(
             @Param("eventId") Long eventId, @Param("status") SeatStatus status);
 }

--- a/src/main/java/com/DBP/ticketing_backend/domain/seat/repository/SeatRepository.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/seat/repository/SeatRepository.java
@@ -3,7 +3,9 @@ package com.DBP.ticketing_backend.domain.seat.repository;
 import com.DBP.ticketing_backend.domain.seat.entity.Seat;
 import com.DBP.ticketing_backend.domain.seat.enums.SeatStatus;
 
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -22,4 +24,11 @@ public interface SeatRepository extends JpaRepository<Seat, Long> {
     //    Optional<Seat> findByIdWithLock(Long seatId);
 
     Optional<Seat> findFirstByEvent_EventIdAndStatus(Long eventId, SeatStatus seatStatus);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select s from Seat s where s.event.eventId = :eventId and s.status = :status order by s.seatId asc limit 1")
+    Optional<Seat> findFirstByEvent_EventIdAndStatusOrderBySeatIdAscWithLock(
+        @Param("eventId") Long eventId,
+        @Param("status") SeatStatus status
+    );
 }

--- a/src/main/java/com/DBP/ticketing_backend/domain/seat/repository/SeatRepository.java
+++ b/src/main/java/com/DBP/ticketing_backend/domain/seat/repository/SeatRepository.java
@@ -4,6 +4,7 @@ import com.DBP.ticketing_backend.domain.seat.entity.Seat;
 import com.DBP.ticketing_backend.domain.seat.enums.SeatStatus;
 
 import jakarta.persistence.LockModeType;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
@@ -26,9 +27,9 @@ public interface SeatRepository extends JpaRepository<Seat, Long> {
     Optional<Seat> findFirstByEvent_EventIdAndStatus(Long eventId, SeatStatus seatStatus);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("select s from Seat s where s.event.eventId = :eventId and s.status = :status order by s.seatId asc limit 1")
+    @Query(
+            "select s from Seat s where s.event.eventId = :eventId and s.status = :status order by"
+                + " s.seatId asc limit 1")
     Optional<Seat> findFirstByEvent_EventIdAndStatusOrderBySeatIdAscWithLock(
-        @Param("eventId") Long eventId,
-        @Param("status") SeatStatus status
-    );
+            @Param("eventId") Long eventId, @Param("status") SeatStatus status);
 }

--- a/src/main/java/com/DBP/ticketing_backend/global/config/WebConfig.java
+++ b/src/main/java/com/DBP/ticketing_backend/global/config/WebConfig.java
@@ -1,7 +1,9 @@
 package com.DBP.ticketing_backend.global.config;
 
 import com.DBP.ticketing_backend.global.interceptor.QueueTokenInterceptor;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -15,9 +17,9 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(queueTokenInterceptor)
-            // 1. 좌석 조회 차단
-            .addPathPatterns("/api/seat/**")
-            // 2. 예매 생성 차단
-            .addPathPatterns("/api/bookings");
+                // 1. 좌석 조회 차단
+                .addPathPatterns("/api/seat/**")
+                // 2. 예매 생성 차단
+                .addPathPatterns("/api/bookings");
     }
 }

--- a/src/main/java/com/DBP/ticketing_backend/global/config/WebConfig.java
+++ b/src/main/java/com/DBP/ticketing_backend/global/config/WebConfig.java
@@ -1,0 +1,25 @@
+package com.DBP.ticketing_backend.global.config;
+
+import com.DBP.ticketing_backend.global.interceptor.QueueTokenInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final QueueTokenInterceptor queueTokenInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(queueTokenInterceptor)
+            // 1. 좌석 조회 차단 (대기열 통과해야 조회 가능)
+            .addPathPatterns("/api/seat/**")
+            // 2. 예매 생성 차단 (우회 방지)
+            // 단, 내 예매 내역 조회(/my)나 취소, 결제는 허용해야 하므로 정확한 경로 지정 필요
+            // (Controller 경로가 /api/booking 이라면 아래와 같이 설정)
+            .addPathPatterns("/api/booking");
+    }
+}

--- a/src/main/java/com/DBP/ticketing_backend/global/config/WebConfig.java
+++ b/src/main/java/com/DBP/ticketing_backend/global/config/WebConfig.java
@@ -15,11 +15,9 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(queueTokenInterceptor)
-            // 1. 좌석 조회 차단 (대기열 통과해야 조회 가능)
+            // 1. 좌석 조회 차단
             .addPathPatterns("/api/seat/**")
-            // 2. 예매 생성 차단 (우회 방지)
-            // 단, 내 예매 내역 조회(/my)나 취소, 결제는 허용해야 하므로 정확한 경로 지정 필요
-            // (Controller 경로가 /api/booking 이라면 아래와 같이 설정)
-            .addPathPatterns("/api/booking");
+            // 2. 예매 생성 차단
+            .addPathPatterns("/api/bookings");
     }
 }

--- a/src/main/java/com/DBP/ticketing_backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/DBP/ticketing_backend/global/exception/ErrorCode.java
@@ -25,7 +25,8 @@ public enum ErrorCode {
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
     UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "권한이 없는 접근입니다."),
     INVALID_SEAT_STATUS(HttpStatus.UNAUTHORIZED, "유효하지 않은 좌석 상태입니다."),
-
+    INVALID_QUEUE_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 대기열 토큰입니다."),
+    QUEUE_TOKEN_EXPIRED(HttpStatus.FORBIDDEN, "대기열 입장 권한이 만료되었거나 없습니다. 다시 줄을 서주세요."),
     // 404 Not Found: 리소스를 찾을 수 없음
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자를 찾을 수 없습니다."),
     HOST_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 호스트를 찾을 수 없습니다."),

--- a/src/main/java/com/DBP/ticketing_backend/global/interceptor/QueueTokenInterceptor.java
+++ b/src/main/java/com/DBP/ticketing_backend/global/interceptor/QueueTokenInterceptor.java
@@ -1,12 +1,15 @@
 package com.DBP.ticketing_backend.global.interceptor;
 
-import com.DBP.ticketing_backend.global.exception.CustomException;
 import com.DBP.ticketing_backend.domain.queue.service.WaitingQueueService;
+import com.DBP.ticketing_backend.global.exception.CustomException;
 import com.DBP.ticketing_backend.global.exception.ErrorCode;
+
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.servlet.HandlerInterceptor;
@@ -19,7 +22,8 @@ public class QueueTokenInterceptor implements HandlerInterceptor {
     private final WaitingQueueService waitingQueueService;
 
     @Override
-    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+    public boolean preHandle(
+            HttpServletRequest request, HttpServletResponse response, Object handler) {
         // Preflight 요청(OPTIONS)은 통과
         if (request.getMethod().equals("OPTIONS")) {
             return true;
@@ -27,7 +31,7 @@ public class QueueTokenInterceptor implements HandlerInterceptor {
 
         // 1. 헤더 추출 (프론트엔드가 보내줘야 함)
         String userIdStr = request.getHeader("Queue-Token"); // 유저 ID (토큰 대신 사용)
-        String eventIdStr = request.getHeader("Event-Id");   // 이벤트 ID
+        String eventIdStr = request.getHeader("Event-Id"); // 이벤트 ID
 
         // 2. 헤더 누락 검사
         if (!StringUtils.hasText(userIdStr) || !StringUtils.hasText(eventIdStr)) {

--- a/src/main/java/com/DBP/ticketing_backend/global/interceptor/QueueTokenInterceptor.java
+++ b/src/main/java/com/DBP/ticketing_backend/global/interceptor/QueueTokenInterceptor.java
@@ -1,0 +1,51 @@
+package com.DBP.ticketing_backend.global.interceptor;
+
+import com.DBP.ticketing_backend.domain.queue.service.WaitingQueueService;
+import com.DBP.ticketing_backend.global.exception.CustomException;
+import com.DBP.ticketing_backend.global.exception.ErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class QueueTokenInterceptor implements HandlerInterceptor {
+
+    private final WaitingQueueService waitingQueueService;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        // Preflight 요청(OPTIONS)은 통과
+        if (request.getMethod().equals("OPTIONS")) {
+            return true;
+        }
+
+        // 1. 헤더 추출 (프론트엔드가 보내줘야 함)
+        String userIdStr = request.getHeader("Queue-Token"); // 유저 ID (토큰 대신 사용)
+        String eventIdStr = request.getHeader("Event-Id");   // 이벤트 ID
+
+        // 2. 헤더 누락 검사
+        if (!StringUtils.hasText(userIdStr) || !StringUtils.hasText(eventIdStr)) {
+            throw new CustomException(ErrorCode.INVALID_QUEUE_TOKEN);
+        }
+
+        try {
+            Long userId = Long.valueOf(userIdStr);
+            Long eventId = Long.valueOf(eventIdStr);
+
+            // 3. Redis 검증 (Active 목록에 있는지 확인)
+            if (!waitingQueueService.isActive(eventId, userId)) {
+                throw new CustomException(ErrorCode.QUEUE_TOKEN_EXPIRED);
+            }
+        } catch (NumberFormatException e) {
+            throw new CustomException(ErrorCode.INVALID_QUEUE_TOKEN);
+        }
+
+        return true; // 통과
+    }
+}

--- a/src/main/java/com/DBP/ticketing_backend/global/interceptor/QueueTokenInterceptor.java
+++ b/src/main/java/com/DBP/ticketing_backend/global/interceptor/QueueTokenInterceptor.java
@@ -1,7 +1,7 @@
 package com.DBP.ticketing_backend.global.interceptor;
 
-import com.DBP.ticketing_backend.domain.queue.service.WaitingQueueService;
 import com.DBP.ticketing_backend.global.exception.CustomException;
+import com.DBP.ticketing_backend.domain.queue.service.WaitingQueueService;
 import com.DBP.ticketing_backend.global.exception.ErrorCode;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
- #19 

## 📝작업 내용
- '좌석 조회'와 '예매 생성'에 대해서는 Interceptor를 통해 '대기열 입장'에서 얻은 token을 먼저 확인하도록 설정
- waiting_queue 동시 진입한 N명 중 MAX_USERS 만큼씩 active_queue에 진입
- active_queue 진입 여부를 '내 순서 확인' API로 확인
- waiting_queue 데이터는 1. active_queue 입장 2. 한 시간 타임아웃 3. 이벤트 종료 를 통해 정리
- active_queue 데이터는 1. 결제 성공 2. 예매 취소 3. 5분 타임아웃 을 통해 정리

## 📸 스크린샷 (선택)
<img width="2022" height="1072" alt="image" src="https://github.com/user-attachments/assets/8096c18b-1068-4a0b-b96a-2584e4fc350b" />


## 🧪 테스트 여부
- [ ] 테스트 코드를 작성함
- [ ] 테스트를 수행함

## 💬리뷰 요구사항(선택)
- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?